### PR TITLE
staticcheck can be replaced with golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,6 @@ on:
     branches: [ main ]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -32,27 +31,3 @@ jobs:
       
     - name: Test Race
       run:  go test -race -v ./...
-      
-  static_analysis:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.x
-        
-    - name: Go Vet
-      run: |
-        go vet ./...
-    
-    - name: Gofmt
-      run: |
-        diff -u <(echo -n) <(gofmt -d -s **/*.go)
-             
-    - name: Staticcheck
-      run: |
-        go install honnef.co/go/tools/cmd/staticcheck@latest
-        staticcheck $(ls -d ./*/)
-      

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+run:
+  timeout: 1m
+  skip-dirs:
+    - pathgen/testdata
+
+linters:
+  enable:
+    - gofmt


### PR DESCRIPTION
* Golanglint-ci is superset of staticcheck so remove static check