### PR TITLE
Add logutil.LogByLine to avoid log truncation on logging SetRequests.

### DIFF
--- a/internal/logutil/logutil.go
+++ b/internal/logutil/logutil.go
@@ -1,0 +1,27 @@
+package logutil
+
+import (
+	"strings"
+
+	log "github.com/golang/glog"
+)
+
+const (
+	// logLimit is used by logging helpers to avoid log truncation on some systems.
+	logLimit = 15000
+)
+
+// LogByLine logs the message line-by-line, and splits lines as well given the
+// log limit.
+func LogByLine(logLevel log.Level, message string) {
+	for _, line := range strings.Split(message, "\n") {
+		length := len(line)
+		for startIndex := 0; startIndex < length; startIndex += logLimit {
+			endIndex := startIndex + logLimit
+			if endIndex > length {
+				endIndex = length
+			}
+			log.V(logLevel).Info(line[startIndex:endIndex])
+		}
+	}
+}

--- a/internal/logutil/logutil.go
+++ b/internal/logutil/logutil.go
@@ -1,6 +1,7 @@
 package logutil
 
 import (
+	"bufio"
 	"strings"
 
 	log "github.com/golang/glog"
@@ -14,7 +15,9 @@ const (
 // LogByLine logs the message line-by-line, and splits lines as well given the
 // log limit.
 func LogByLine(logLevel log.Level, message string) {
-	for _, line := range strings.Split(message, "\n") {
+	scanner := bufio.NewScanner(strings.NewReader(message))
+	for scanner.Scan() {
+		line := scanner.Text()
 		length := len(line)
 		for startIndex := 0; startIndex < length; startIndex += logLimit {
 			endIndex := startIndex + logLimit
@@ -23,5 +26,8 @@ func LogByLine(logLevel log.Level, message string) {
 			}
 			log.V(logLevel).Info(line[startIndex:endIndex])
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Warningf("ygnmi/logutil: error while scanning log input: %v", err)
 	}
 }

--- a/ygnmi/gnmi.go
+++ b/ygnmi/gnmi.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openconfig/ygnmi/internal/logutil"
 	"github.com/openconfig/ygot/util"
 	"github.com/openconfig/ygot/ygot"
 	"google.golang.org/grpc/codes"
@@ -317,7 +318,7 @@ func set[T any](ctx context.Context, c *Client, q ConfigQuery[T], val T, op setO
 	req.Prefix = &gpb.Path{
 		Target: c.target,
 	}
-	log.V(c.requestLogLevel).Info(prettySetRequest(req))
+	logutil.LogByLine(c.requestLogLevel, prettySetRequest(req))
 	resp, err := c.gnmiC.Set(ctx, req)
 	log.V(c.requestLogLevel).Infof("SetResponse:\n%s", prototext.Format(resp))
 

--- a/ygnmi/ygnmi.go
+++ b/ygnmi/ygnmi.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/openconfig/ygnmi/internal/logutil"
 	"github.com/openconfig/ygot/util"
 	"github.com/openconfig/ygot/ygot"
 	"github.com/openconfig/ygot/ytypes"
@@ -593,7 +594,7 @@ func (sb *SetBatch) Set(ctx context.Context, c *Client, opts ...Option) (*Result
 	req.Prefix = &gpb.Path{
 		Target: c.target,
 	}
-	log.V(c.requestLogLevel).Info(prettySetRequest(req))
+	logutil.LogByLine(c.requestLogLevel, prettySetRequest(req))
 	resp, err := c.gnmiC.Set(ctx, req)
 	log.V(c.requestLogLevel).Infof("SetResponse:\n%s", prototext.Format(resp))
 	return responseToResult(resp), err


### PR DESCRIPTION
Some systems have a limit. This is currently hardcoded to 15000 bytes.

```
I0131 14:47:31.909694 2538970 logutil.go:27] SetRequest:
I0131 14:47:31.909705 2538970 logutil.go:27] prefix:  {
I0131 14:47:31.909712 2538970 logutil.go:27]   target:  "dut"
I0131 14:47:31.909719 2538970 logutil.go:27] }
I0131 14:47:31.909726 2538970 logutil.go:27] delete:  {
I0131 14:47:31.909734 2538970 logutil.go:27]   origin:  "openconfig"
I0131 14:47:31.909741 2538970 logutil.go:27]   elem:  {
I0131 14:47:31.909748 2538970 logutil.go:27]     name:  "parent"
I0131 14:47:31.909755 2538970 logutil.go:27]   }
I0131 14:47:31.909763 2538970 logutil.go:27]   elem:  {
I0131 14:47:31.909770 2538970 logutil.go:27]     name:  "child"
I0131 14:47:31.909777 2538970 logutil.go:27]   }
I0131 14:47:31.909784 2538970 logutil.go:27]   elem:  {
I0131 14:47:31.909791 2538970 logutil.go:27]     name:  "config"
I0131 14:47:31.909799 2538970 logutil.go:27]   }
I0131 14:47:31.909806 2538970 logutil.go:27]   elem:  {
I0131 14:47:31.909813 2538970 logutil.go:27]     name:  "one"
I0131 14:47:31.909820 2538970 logutil.go:27]   }
I0131 14:47:31.909828 2538970 logutil.go:27] }
I0131 14:47:31.909835 2538970 logutil.go:27] update:  {
I0131 14:47:31.909842 2538970 logutil.go:27]   path:  {
I0131 14:47:31.909849 2538970 logutil.go:27]     origin:  "openconfig"
I0131 14:47:31.909856 2538970 logutil.go:27]     elem:  {
I0131 14:47:31.909876 2538970 logutil.go:27]       name:  "parent"
I0131 14:47:31.909881 2538970 logutil.go:27]     }
I0131 14:47:31.909886 2538970 logutil.go:27]     elem:  {
I0131 14:47:31.909891 2538970 logutil.go:27]       name:  "child"
I0131 14:47:31.909897 2538970 logutil.go:27]     }
I0131 14:47:31.909902 2538970 logutil.go:27]   }
I0131 14:47:31.909907 2538970 logutil.go:27]   val:  {
I0131 14:47:31.909912 2538970 logutil.go:27]     json_ietf_val:  "{\n  \"openconfig-simple:config\": {\n    \"one\": \"foo\"\n  }\n}"
I0131 14:47:31.909917 2538970 logutil.go:27]   }
I0131 14:47:31.909922 2538970 logutil.go:27] }
I0131 14:47:31.909927 2538970 logutil.go:27] -------delete path #0------
I0131 14:47:31.909932 2538970 logutil.go:27] /parent/child/config/one
I0131 14:47:31.909937 2538970 logutil.go:27] -------update path/value pair #0------
I0131 14:47:31.909943 2538970 logutil.go:27] /parent/child
I0131 14:47:31.909948 2538970 logutil.go:27] {
I0131 14:47:31.909953 2538970 logutil.go:27]   "openconfig-simple:config": {
I0131 14:47:31.909958 2538970 logutil.go:27]     "one": "foo"
I0131 14:47:31.909963 2538970 logutil.go:27]   }
I0131 14:47:31.909968 2538970 logutil.go:27] }
```