### PR TITLE
Generate extras/plugin at same time as child constructors.

### DIFF
--- a/exampleoc/nested/nested-0.go
+++ b/exampleoc/nested/nested-0.go
@@ -1351,72 +1351,6 @@ type A_B_C_D_E_F_G_H_I_J_K_L_M_FooPathAny struct {
 }
 
 // State returns a Query that can be used in gNMI operations.
-func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
-		"A_B_C_D_E_F_G_H_I_J_K_L_M",
-		true,
-		n,
-		nil,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
-		"A_B_C_D_E_F_G_H_I_J_K_L_M",
-		true,
-		n,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
-		"A_B_C_D_E_F_G_H_I_J_K_L_M",
-		false,
-		n,
-		nil,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
-		"A_B_C_D_E_F_G_H_I_J_K_L_M",
-		false,
-		n,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
 //
 //	Defining module:      "openconfig-nested"
 //	Instantiating module: "openconfig-nested"
@@ -1528,4 +1462,70 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) Foo() *A_B_C_D_E_F_G_H_I_J_K_L_M_FooP
 		),
 		parent: n,
 	}
+}
+
+// State returns a Query that can be used in gNMI operations.
+func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
+	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
+		"A_B_C_D_E_F_G_H_I_J_K_L_M",
+		true,
+		n,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// State returns a Query that can be used in gNMI operations.
+func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
+	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
+		"A_B_C_D_E_F_G_H_I_J_K_L_M",
+		true,
+		n,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
+	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
+		"A_B_C_D_E_F_G_H_I_J_K_L_M",
+		false,
+		n,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
+	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
+		"A_B_C_D_E_F_G_H_I_J_K_L_M",
+		false,
+		n,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
 }

--- a/exampleoc/simple/simple-0.go
+++ b/exampleoc/simple/simple-0.go
@@ -165,72 +165,6 @@ type Parent_Child_FivePathAny struct {
 }
 
 // State returns a Query that can be used in gNMI operations.
-func (n *Parent_ChildPath) State() ygnmi.SingletonQuery[*oc.Parent_Child] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Parent_Child](
-		"Parent_Child",
-		true,
-		n,
-		nil,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *Parent_ChildPathAny) State() ygnmi.WildcardQuery[*oc.Parent_Child] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Parent_Child](
-		"Parent_Child",
-		true,
-		n,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *Parent_ChildPath) Config() ygnmi.ConfigQuery[*oc.Parent_Child] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Parent_Child](
-		"Parent_Child",
-		false,
-		n,
-		nil,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *Parent_ChildPathAny) Config() ygnmi.WildcardQuery[*oc.Parent_Child] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Parent_Child](
-		"Parent_Child",
-		false,
-		n,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
 //
 //	Defining module:      "openconfig-simple"
 //	Instantiating module: "openconfig-simple"
@@ -352,6 +286,18 @@ func (n *Parent_Child_FivePathAny) Config() ygnmi.WildcardQuery[float32] {
 			}
 		},
 	)
+}
+
+// Parent_Child_FourPath represents the /openconfig-simple/parent/child/state/four YANG schema element.
+type Parent_Child_FourPath struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
+// Parent_Child_FourPathAny represents the wildcard version of the /openconfig-simple/parent/child/state/four YANG schema element.
+type Parent_Child_FourPathAny struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
 }
 
 // State returns a Query that can be used in gNMI operations.
@@ -476,6 +422,18 @@ func (n *Parent_Child_FourPathAny) Config() ygnmi.WildcardQuery[oc.Binary] {
 			}
 		},
 	)
+}
+
+// Parent_Child_OnePath represents the /openconfig-simple/parent/child/state/one YANG schema element.
+type Parent_Child_OnePath struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
+// Parent_Child_OnePathAny represents the wildcard version of the /openconfig-simple/parent/child/state/one YANG schema element.
+type Parent_Child_OnePathAny struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
 }
 
 // State returns a Query that can be used in gNMI operations.
@@ -618,6 +576,18 @@ func (n *Parent_Child_OnePathAny) Config() ygnmi.WildcardQuery[string] {
 	)
 }
 
+// Parent_Child_SixPath represents the /openconfig-simple/parent/child/state/six YANG schema element.
+type Parent_Child_SixPath struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
+// Parent_Child_SixPathAny represents the wildcard version of the /openconfig-simple/parent/child/state/six YANG schema element.
+type Parent_Child_SixPathAny struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
 // State returns a Query that can be used in gNMI operations.
 //
 //	Defining module:      "openconfig-simple"
@@ -740,6 +710,18 @@ func (n *Parent_Child_SixPathAny) Config() ygnmi.WildcardQuery[[]float32] {
 			}
 		},
 	)
+}
+
+// Parent_Child_ThreePath represents the /openconfig-simple/parent/child/state/three YANG schema element.
+type Parent_Child_ThreePath struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
+// Parent_Child_ThreePathAny represents the wildcard version of the /openconfig-simple/parent/child/state/three YANG schema element.
+type Parent_Child_ThreePathAny struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
 }
 
 // State returns a Query that can be used in gNMI operations.
@@ -866,6 +848,18 @@ func (n *Parent_Child_ThreePathAny) Config() ygnmi.WildcardQuery[oc.E_Child_Thre
 	)
 }
 
+// Parent_Child_TwoPath represents the /openconfig-simple/parent/child/state/two YANG schema element.
+type Parent_Child_TwoPath struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
+// Parent_Child_TwoPathAny represents the wildcard version of the /openconfig-simple/parent/child/state/two YANG schema element.
+type Parent_Child_TwoPathAny struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
 // State returns a Query that can be used in gNMI operations.
 //
 //	Defining module:      "openconfig-simple"
@@ -934,66 +928,6 @@ func (n *Parent_Child_TwoPathAny) State() ygnmi.WildcardQuery[string] {
 			}
 		},
 	)
-}
-
-// Parent_Child_FourPath represents the /openconfig-simple/parent/child/state/four YANG schema element.
-type Parent_Child_FourPath struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
-// Parent_Child_FourPathAny represents the wildcard version of the /openconfig-simple/parent/child/state/four YANG schema element.
-type Parent_Child_FourPathAny struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
-// Parent_Child_OnePath represents the /openconfig-simple/parent/child/state/one YANG schema element.
-type Parent_Child_OnePath struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
-// Parent_Child_OnePathAny represents the wildcard version of the /openconfig-simple/parent/child/state/one YANG schema element.
-type Parent_Child_OnePathAny struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
-// Parent_Child_SixPath represents the /openconfig-simple/parent/child/state/six YANG schema element.
-type Parent_Child_SixPath struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
-// Parent_Child_SixPathAny represents the wildcard version of the /openconfig-simple/parent/child/state/six YANG schema element.
-type Parent_Child_SixPathAny struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
-// Parent_Child_ThreePath represents the /openconfig-simple/parent/child/state/three YANG schema element.
-type Parent_Child_ThreePath struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
-// Parent_Child_ThreePathAny represents the wildcard version of the /openconfig-simple/parent/child/state/three YANG schema element.
-type Parent_Child_ThreePathAny struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
-// Parent_Child_TwoPath represents the /openconfig-simple/parent/child/state/two YANG schema element.
-type Parent_Child_TwoPath struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
-// Parent_Child_TwoPathAny represents the wildcard version of the /openconfig-simple/parent/child/state/two YANG schema element.
-type Parent_Child_TwoPathAny struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
 }
 
 // Parent_ChildPath represents the /openconfig-simple/parent/child YANG schema element.
@@ -1210,6 +1144,72 @@ func (n *Parent_ChildPathAny) Two() *Parent_Child_TwoPathAny {
 	}
 }
 
+// State returns a Query that can be used in gNMI operations.
+func (n *Parent_ChildPath) State() ygnmi.SingletonQuery[*oc.Parent_Child] {
+	return ygnmi.NewNonLeafSingletonQuery[*oc.Parent_Child](
+		"Parent_Child",
+		true,
+		n,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// State returns a Query that can be used in gNMI operations.
+func (n *Parent_ChildPathAny) State() ygnmi.WildcardQuery[*oc.Parent_Child] {
+	return ygnmi.NewNonLeafWildcardQuery[*oc.Parent_Child](
+		"Parent_Child",
+		true,
+		n,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+func (n *Parent_ChildPath) Config() ygnmi.ConfigQuery[*oc.Parent_Child] {
+	return ygnmi.NewNonLeafConfigQuery[*oc.Parent_Child](
+		"Parent_Child",
+		false,
+		n,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+func (n *Parent_ChildPathAny) Config() ygnmi.WildcardQuery[*oc.Parent_Child] {
+	return ygnmi.NewNonLeafWildcardQuery[*oc.Parent_Child](
+		"Parent_Child",
+		false,
+		n,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
 // RemoteContainer_ALeafPath represents the /openconfig-simple/remote-container/state/a-leaf YANG schema element.
 type RemoteContainer_ALeafPath struct {
 	*ygnmi.NodePath
@@ -1220,72 +1220,6 @@ type RemoteContainer_ALeafPath struct {
 type RemoteContainer_ALeafPathAny struct {
 	*ygnmi.NodePath
 	parent ygnmi.PathStruct
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *RemoteContainerPath) State() ygnmi.SingletonQuery[*oc.RemoteContainer] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.RemoteContainer](
-		"RemoteContainer",
-		true,
-		n,
-		nil,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *RemoteContainerPathAny) State() ygnmi.WildcardQuery[*oc.RemoteContainer] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.RemoteContainer](
-		"RemoteContainer",
-		true,
-		n,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *RemoteContainerPath) Config() ygnmi.ConfigQuery[*oc.RemoteContainer] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.RemoteContainer](
-		"RemoteContainer",
-		false,
-		n,
-		nil,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *RemoteContainerPathAny) Config() ygnmi.WildcardQuery[*oc.RemoteContainer] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.RemoteContainer](
-		"RemoteContainer",
-		false,
-		n,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
 }
 
 // State returns a Query that can be used in gNMI operations.
@@ -1470,4 +1404,70 @@ func (n *RemoteContainerPathAny) ALeaf() *RemoteContainer_ALeafPathAny {
 		),
 		parent: n,
 	}
+}
+
+// State returns a Query that can be used in gNMI operations.
+func (n *RemoteContainerPath) State() ygnmi.SingletonQuery[*oc.RemoteContainer] {
+	return ygnmi.NewNonLeafSingletonQuery[*oc.RemoteContainer](
+		"RemoteContainer",
+		true,
+		n,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// State returns a Query that can be used in gNMI operations.
+func (n *RemoteContainerPathAny) State() ygnmi.WildcardQuery[*oc.RemoteContainer] {
+	return ygnmi.NewNonLeafWildcardQuery[*oc.RemoteContainer](
+		"RemoteContainer",
+		true,
+		n,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+func (n *RemoteContainerPath) Config() ygnmi.ConfigQuery[*oc.RemoteContainer] {
+	return ygnmi.NewNonLeafConfigQuery[*oc.RemoteContainer](
+		"RemoteContainer",
+		false,
+		n,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+func (n *RemoteContainerPathAny) Config() ygnmi.WildcardQuery[*oc.RemoteContainer] {
+	return ygnmi.NewNonLeafWildcardQuery[*oc.RemoteContainer](
+		"RemoteContainer",
+		false,
+		n,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
 }

--- a/exampleoc/withlistval/withlistval-0.go
+++ b/exampleoc/withlistval/withlistval-0.go
@@ -315,72 +315,6 @@ type Model_MultiKey_Key1PathAny struct {
 }
 
 // State returns a Query that can be used in gNMI operations.
-func (n *Model_MultiKeyPath) State() ygnmi.SingletonQuery[*oc.Model_MultiKey] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_MultiKey](
-		"Model_MultiKey",
-		true,
-		n,
-		nil,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *Model_MultiKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_MultiKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_MultiKey](
-		"Model_MultiKey",
-		true,
-		n,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *Model_MultiKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_MultiKey] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Model_MultiKey](
-		"Model_MultiKey",
-		false,
-		n,
-		nil,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *Model_MultiKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_MultiKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_MultiKey](
-		"Model_MultiKey",
-		false,
-		n,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
 //
 //	Defining module:      "openconfig-withlistval"
 //	Instantiating module: "openconfig-withlistval"
@@ -518,6 +452,18 @@ func (n *Model_MultiKey_Key1PathAny) Config() ygnmi.WildcardQuery[uint32] {
 			}
 		},
 	)
+}
+
+// Model_MultiKey_Key2Path represents the /openconfig-withlistval/model/b/multi-key/state/key2 YANG schema element.
+type Model_MultiKey_Key2Path struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
+// Model_MultiKey_Key2PathAny represents the wildcard version of the /openconfig-withlistval/model/b/multi-key/state/key2 YANG schema element.
+type Model_MultiKey_Key2PathAny struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
 }
 
 // State returns a Query that can be used in gNMI operations.
@@ -660,18 +606,6 @@ func (n *Model_MultiKey_Key2PathAny) Config() ygnmi.WildcardQuery[uint64] {
 	)
 }
 
-// Model_MultiKey_Key2Path represents the /openconfig-withlistval/model/b/multi-key/state/key2 YANG schema element.
-type Model_MultiKey_Key2Path struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
-// Model_MultiKey_Key2PathAny represents the wildcard version of the /openconfig-withlistval/model/b/multi-key/state/key2 YANG schema element.
-type Model_MultiKey_Key2PathAny struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
 // Model_MultiKeyPath represents the /openconfig-withlistval/model/b/multi-key YANG schema element.
 type Model_MultiKeyPath struct {
 	*ygnmi.NodePath
@@ -750,6 +684,72 @@ func (n *Model_MultiKeyPathAny) Key2() *Model_MultiKey_Key2PathAny {
 	}
 }
 
+// State returns a Query that can be used in gNMI operations.
+func (n *Model_MultiKeyPath) State() ygnmi.SingletonQuery[*oc.Model_MultiKey] {
+	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_MultiKey](
+		"Model_MultiKey",
+		true,
+		n,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// State returns a Query that can be used in gNMI operations.
+func (n *Model_MultiKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_MultiKey] {
+	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_MultiKey](
+		"Model_MultiKey",
+		true,
+		n,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+func (n *Model_MultiKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_MultiKey] {
+	return ygnmi.NewNonLeafConfigQuery[*oc.Model_MultiKey](
+		"Model_MultiKey",
+		false,
+		n,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+func (n *Model_MultiKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_MultiKey] {
+	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_MultiKey](
+		"Model_MultiKey",
+		false,
+		n,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
 // Model_NoKeyPath represents the /openconfig-withlistval/model/c/no-key YANG schema element.
 type Model_NoKeyPath struct {
 	*ygnmi.NodePath
@@ -803,39 +803,6 @@ type Model_NoKey_Foo_KeyPath struct {
 type Model_NoKey_Foo_KeyPathAny struct {
 	*ygnmi.NodePath
 	parent ygnmi.PathStruct
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *Model_NoKey_FooPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey_Foo] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_NoKey_Foo](
-		"Model_NoKey_Foo",
-		true,
-		n,
-		nil,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *Model_NoKey_FooPathAny) State() ygnmi.WildcardQuery[*oc.Model_NoKey_Foo] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_NoKey_Foo](
-		"Model_NoKey_Foo",
-		true,
-		n,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
 }
 
 // State returns a Query that can be used in gNMI operations.
@@ -908,6 +875,18 @@ func (n *Model_NoKey_Foo_KeyPathAny) State() ygnmi.WildcardQuery[string] {
 	)
 }
 
+// Model_NoKey_Foo_ValuePath represents the /openconfig-withlistval/model/c/no-key/foo/state/value YANG schema element.
+type Model_NoKey_Foo_ValuePath struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
+// Model_NoKey_Foo_ValuePathAny represents the wildcard version of the /openconfig-withlistval/model/c/no-key/foo/state/value YANG schema element.
+type Model_NoKey_Foo_ValuePathAny struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
 // State returns a Query that can be used in gNMI operations.
 //
 //	Defining module:      "openconfig-withlistval"
@@ -976,18 +955,6 @@ func (n *Model_NoKey_Foo_ValuePathAny) State() ygnmi.WildcardQuery[int64] {
 			}
 		},
 	)
-}
-
-// Model_NoKey_Foo_ValuePath represents the /openconfig-withlistval/model/c/no-key/foo/state/value YANG schema element.
-type Model_NoKey_Foo_ValuePath struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
-// Model_NoKey_Foo_ValuePathAny represents the wildcard version of the /openconfig-withlistval/model/c/no-key/foo/state/value YANG schema element.
-type Model_NoKey_Foo_ValuePathAny struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
 }
 
 // Model_NoKey_FooPath represents the /openconfig-withlistval/model/c/no-key/foo YANG schema element.
@@ -1068,6 +1035,39 @@ func (n *Model_NoKey_FooPathAny) Value() *Model_NoKey_Foo_ValuePathAny {
 	}
 }
 
+// State returns a Query that can be used in gNMI operations.
+func (n *Model_NoKey_FooPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey_Foo] {
+	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_NoKey_Foo](
+		"Model_NoKey_Foo",
+		true,
+		n,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// State returns a Query that can be used in gNMI operations.
+func (n *Model_NoKey_FooPathAny) State() ygnmi.WildcardQuery[*oc.Model_NoKey_Foo] {
+	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_NoKey_Foo](
+		"Model_NoKey_Foo",
+		true,
+		n,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
 // Model_SingleKey_KeyPath represents the /openconfig-withlistval/model/a/single-key/state/key YANG schema element.
 type Model_SingleKey_KeyPath struct {
 	*ygnmi.NodePath
@@ -1078,72 +1078,6 @@ type Model_SingleKey_KeyPath struct {
 type Model_SingleKey_KeyPathAny struct {
 	*ygnmi.NodePath
 	parent ygnmi.PathStruct
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKeyPath) State() ygnmi.SingletonQuery[*oc.Model_SingleKey] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_SingleKey](
-		"Model_SingleKey",
-		true,
-		n,
-		nil,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_SingleKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_SingleKey](
-		"Model_SingleKey",
-		true,
-		n,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_SingleKey] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Model_SingleKey](
-		"Model_SingleKey",
-		false,
-		n,
-		nil,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_SingleKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_SingleKey](
-		"Model_SingleKey",
-		false,
-		n,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-	)
 }
 
 // State returns a Query that can be used in gNMI operations.
@@ -1286,6 +1220,18 @@ func (n *Model_SingleKey_KeyPathAny) Config() ygnmi.WildcardQuery[string] {
 	)
 }
 
+// Model_SingleKey_ValuePath represents the /openconfig-withlistval/model/a/single-key/state/value YANG schema element.
+type Model_SingleKey_ValuePath struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
+// Model_SingleKey_ValuePathAny represents the wildcard version of the /openconfig-withlistval/model/a/single-key/state/value YANG schema element.
+type Model_SingleKey_ValuePathAny struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
 // State returns a Query that can be used in gNMI operations.
 //
 //	Defining module:      "openconfig-withlistval"
@@ -1426,18 +1372,6 @@ func (n *Model_SingleKey_ValuePathAny) Config() ygnmi.WildcardQuery[int64] {
 	)
 }
 
-// Model_SingleKey_ValuePath represents the /openconfig-withlistval/model/a/single-key/state/value YANG schema element.
-type Model_SingleKey_ValuePath struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
-// Model_SingleKey_ValuePathAny represents the wildcard version of the /openconfig-withlistval/model/a/single-key/state/value YANG schema element.
-type Model_SingleKey_ValuePathAny struct {
-	*ygnmi.NodePath
-	parent ygnmi.PathStruct
-}
-
 // Model_SingleKeyPath represents the /openconfig-withlistval/model/a/single-key YANG schema element.
 type Model_SingleKeyPath struct {
 	*ygnmi.NodePath
@@ -1514,4 +1448,70 @@ func (n *Model_SingleKeyPathAny) Value() *Model_SingleKey_ValuePathAny {
 		),
 		parent: n,
 	}
+}
+
+// State returns a Query that can be used in gNMI operations.
+func (n *Model_SingleKeyPath) State() ygnmi.SingletonQuery[*oc.Model_SingleKey] {
+	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_SingleKey](
+		"Model_SingleKey",
+		true,
+		n,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// State returns a Query that can be used in gNMI operations.
+func (n *Model_SingleKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_SingleKey] {
+	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_SingleKey](
+		"Model_SingleKey",
+		true,
+		n,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+func (n *Model_SingleKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_SingleKey] {
+	return ygnmi.NewNonLeafConfigQuery[*oc.Model_SingleKey](
+		"Model_SingleKey",
+		false,
+		n,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+func (n *Model_SingleKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_SingleKey] {
+	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_SingleKey](
+		"Model_SingleKey",
+		false,
+		n,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+	)
 }

--- a/pathgen/pathgen_test.go
+++ b/pathgen/pathgen_test.go
@@ -3122,7 +3122,7 @@ func (n *ListPathAny) WithUnionKey(UnionKey oc.RootElementModule_List_UnionKey_U
 	for _, tt := range tests {
 		if tt.want != nil {
 			t.Run(tt.name, func(t *testing.T) {
-				got, gotErr := generateDirectorySnippet(tt.inDirectory, directories, "oc.", tt.inPathStructSuffix, true, tt.inSplitByModule, "", tt.inPackageName, tt.inPackageSuffix, tt.inUnifiedPath)
+				got, gotErr := generateDirectorySnippet(tt.inDirectory, directories, nil, nil, "oc.", tt.inPathStructSuffix, true, tt.inSplitByModule, "", tt.inPackageName, tt.inPackageSuffix, tt.inUnifiedPath)
 				if gotErr != nil {
 					t.Fatalf("func generateDirectorySnippet, unexpected error: %v", gotErr)
 				}
@@ -3139,7 +3139,7 @@ func (n *ListPathAny) WithUnionKey(UnionKey oc.RootElementModule_List_UnionKey_U
 
 		if tt.wantNoWildcard != nil {
 			t.Run(tt.name+" no wildcard", func(t *testing.T) {
-				got, gotErr := generateDirectorySnippet(tt.inDirectory, directories, "oc.", tt.inPathStructSuffix, false, tt.inSplitByModule, "", tt.inPackageName, tt.inPackageSuffix, tt.inUnifiedPath)
+				got, gotErr := generateDirectorySnippet(tt.inDirectory, directories, nil, nil, "oc.", tt.inPathStructSuffix, false, tt.inSplitByModule, "", tt.inPackageName, tt.inPackageSuffix, tt.inUnifiedPath)
 				if gotErr != nil {
 					t.Fatalf("func generateDirectorySnippet, unexpected error: %v", gotErr)
 				}


### PR DESCRIPTION
If the constructors are allowed (i.e. the child is accessible), only then will extras be generated. This automatically means the children of unkeyed (and later ordered) lists do not have extras generated.