### PR TITLE
Generate CompressionInfo for OrderedMap PathStructs

### DIFF
--- a/exampleoc/exampleocpath/exampleocpath.go
+++ b/exampleoc/exampleocpath/exampleocpath.go
@@ -134,6 +134,8 @@ func (b *Batch) State() ygnmi.SingletonQuery[*oc.Root] {
 		"Root",
 		true,
 		ygnmi.NewDeviceRootBase(),
+		nil,
+		nil,
 		queryPaths,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -142,6 +144,7 @@ func (b *Batch) State() ygnmi.SingletonQuery[*oc.Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -154,6 +157,8 @@ func (b *Batch) Config() ygnmi.SingletonQuery[*oc.Root] {
 		"Root",
 		false,
 		ygnmi.NewDeviceRootBase(),
+		nil,
+		nil,
 		queryPaths,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -162,6 +167,7 @@ func (b *Batch) Config() ygnmi.SingletonQuery[*oc.Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -180,6 +186,8 @@ func (n *RootPath) State() ygnmi.SingletonQuery[*oc.Root] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -187,6 +195,7 @@ func (n *RootPath) State() ygnmi.SingletonQuery[*oc.Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -197,6 +206,8 @@ func (n *RootPath) Config() ygnmi.ConfigQuery[*oc.Root] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -204,5 +215,6 @@ func (n *RootPath) Config() ygnmi.ConfigQuery[*oc.Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }

--- a/exampleoc/exampleocpath/exampleocpath.go
+++ b/exampleoc/exampleocpath/exampleocpath.go
@@ -130,13 +130,14 @@ func (b *Batch) AddPaths(paths ...ygnmi.PathStruct) *Batch {
 func (b *Batch) State() ygnmi.SingletonQuery[*oc.Root] {
 	queryPaths := make([]ygnmi.PathStruct, len(b.paths))
 	copy(queryPaths, b.paths)
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Root](
+	return ygnmi.NewSingletonQuery[*oc.Root](
 		"Root",
 		true,
+		false,
+		false,
 		ygnmi.NewDeviceRootBase(),
 		nil,
 		nil,
-		queryPaths,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -144,6 +145,7 @@ func (b *Batch) State() ygnmi.SingletonQuery[*oc.Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		queryPaths,
 		nil,
 	)
 }
@@ -153,13 +155,14 @@ func (b *Batch) State() ygnmi.SingletonQuery[*oc.Root] {
 func (b *Batch) Config() ygnmi.SingletonQuery[*oc.Root] {
 	queryPaths := make([]ygnmi.PathStruct, len(b.paths))
 	copy(queryPaths, b.paths)
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Root](
+	return ygnmi.NewSingletonQuery[*oc.Root](
 		"Root",
+		false,
+		false,
 		false,
 		ygnmi.NewDeviceRootBase(),
 		nil,
 		nil,
-		queryPaths,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -167,6 +170,7 @@ func (b *Batch) Config() ygnmi.SingletonQuery[*oc.Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		queryPaths,
 		nil,
 	)
 }
@@ -181,11 +185,12 @@ func binarySliceToFloatSlice(in []oc.Binary) []float32 {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *RootPath) State() ygnmi.SingletonQuery[*oc.Root] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Root](
+	return ygnmi.NewSingletonQuery[*oc.Root](
 		"Root",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -195,17 +200,19 @@ func (n *RootPath) State() ygnmi.SingletonQuery[*oc.Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *RootPath) Config() ygnmi.ConfigQuery[*oc.Root] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Root](
+	return ygnmi.NewConfigQuery[*oc.Root](
 		"Root",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -215,6 +222,7 @@ func (n *RootPath) Config() ygnmi.ConfigQuery[*oc.Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 		nil,
 	)
 }

--- a/exampleoc/nested/nested-0.go
+++ b/exampleoc/nested/nested-0.go
@@ -91,6 +91,8 @@ func (n *APath) State() ygnmi.SingletonQuery[*oc.A] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -98,6 +100,7 @@ func (n *APath) State() ygnmi.SingletonQuery[*oc.A] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -107,6 +110,8 @@ func (n *APathAny) State() ygnmi.WildcardQuery[*oc.A] {
 		"A",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -114,6 +119,7 @@ func (n *APathAny) State() ygnmi.WildcardQuery[*oc.A] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -124,6 +130,8 @@ func (n *APath) Config() ygnmi.ConfigQuery[*oc.A] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -131,6 +139,7 @@ func (n *APath) Config() ygnmi.ConfigQuery[*oc.A] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -140,6 +149,8 @@ func (n *APathAny) Config() ygnmi.WildcardQuery[*oc.A] {
 		"A",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -147,6 +158,7 @@ func (n *APathAny) Config() ygnmi.WildcardQuery[*oc.A] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -199,6 +211,8 @@ func (n *A_BPath) State() ygnmi.SingletonQuery[*oc.A_B] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -206,6 +220,7 @@ func (n *A_BPath) State() ygnmi.SingletonQuery[*oc.A_B] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -215,6 +230,8 @@ func (n *A_BPathAny) State() ygnmi.WildcardQuery[*oc.A_B] {
 		"A_B",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -222,6 +239,7 @@ func (n *A_BPathAny) State() ygnmi.WildcardQuery[*oc.A_B] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -232,6 +250,8 @@ func (n *A_BPath) Config() ygnmi.ConfigQuery[*oc.A_B] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -239,6 +259,7 @@ func (n *A_BPath) Config() ygnmi.ConfigQuery[*oc.A_B] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -248,6 +269,8 @@ func (n *A_BPathAny) Config() ygnmi.WildcardQuery[*oc.A_B] {
 		"A_B",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -255,6 +278,7 @@ func (n *A_BPathAny) Config() ygnmi.WildcardQuery[*oc.A_B] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -307,6 +331,8 @@ func (n *A_B_CPath) State() ygnmi.SingletonQuery[*oc.A_B_C] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -314,6 +340,7 @@ func (n *A_B_CPath) State() ygnmi.SingletonQuery[*oc.A_B_C] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -323,6 +350,8 @@ func (n *A_B_CPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C] {
 		"A_B_C",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -330,6 +359,7 @@ func (n *A_B_CPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -340,6 +370,8 @@ func (n *A_B_CPath) Config() ygnmi.ConfigQuery[*oc.A_B_C] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -347,6 +379,7 @@ func (n *A_B_CPath) Config() ygnmi.ConfigQuery[*oc.A_B_C] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -356,6 +389,8 @@ func (n *A_B_CPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C] {
 		"A_B_C",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -363,6 +398,7 @@ func (n *A_B_CPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -415,6 +451,8 @@ func (n *A_B_C_DPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -422,6 +460,7 @@ func (n *A_B_C_DPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -431,6 +470,8 @@ func (n *A_B_C_DPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D] {
 		"A_B_C_D",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -438,6 +479,7 @@ func (n *A_B_C_DPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -448,6 +490,8 @@ func (n *A_B_C_DPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -455,6 +499,7 @@ func (n *A_B_C_DPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -464,6 +509,8 @@ func (n *A_B_C_DPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D] {
 		"A_B_C_D",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -471,6 +518,7 @@ func (n *A_B_C_DPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -523,6 +571,8 @@ func (n *A_B_C_D_EPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -530,6 +580,7 @@ func (n *A_B_C_D_EPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -539,6 +590,8 @@ func (n *A_B_C_D_EPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E] {
 		"A_B_C_D_E",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -546,6 +599,7 @@ func (n *A_B_C_D_EPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -556,6 +610,8 @@ func (n *A_B_C_D_EPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -563,6 +619,7 @@ func (n *A_B_C_D_EPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -572,6 +629,8 @@ func (n *A_B_C_D_EPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E] {
 		"A_B_C_D_E",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -579,6 +638,7 @@ func (n *A_B_C_D_EPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -631,6 +691,8 @@ func (n *A_B_C_D_E_FPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -638,6 +700,7 @@ func (n *A_B_C_D_E_FPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -647,6 +710,8 @@ func (n *A_B_C_D_E_FPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F] {
 		"A_B_C_D_E_F",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -654,6 +719,7 @@ func (n *A_B_C_D_E_FPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -664,6 +730,8 @@ func (n *A_B_C_D_E_FPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -671,6 +739,7 @@ func (n *A_B_C_D_E_FPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -680,6 +749,8 @@ func (n *A_B_C_D_E_FPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F] {
 		"A_B_C_D_E_F",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -687,6 +758,7 @@ func (n *A_B_C_D_E_FPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -739,6 +811,8 @@ func (n *A_B_C_D_E_F_GPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -746,6 +820,7 @@ func (n *A_B_C_D_E_F_GPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -755,6 +830,8 @@ func (n *A_B_C_D_E_F_GPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G] {
 		"A_B_C_D_E_F_G",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -762,6 +839,7 @@ func (n *A_B_C_D_E_F_GPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -772,6 +850,8 @@ func (n *A_B_C_D_E_F_GPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -779,6 +859,7 @@ func (n *A_B_C_D_E_F_GPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -788,6 +869,8 @@ func (n *A_B_C_D_E_F_GPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G] {
 		"A_B_C_D_E_F_G",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -795,6 +878,7 @@ func (n *A_B_C_D_E_F_GPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -847,6 +931,8 @@ func (n *A_B_C_D_E_F_G_HPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H] 
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -854,6 +940,7 @@ func (n *A_B_C_D_E_F_G_HPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H] 
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -863,6 +950,8 @@ func (n *A_B_C_D_E_F_G_HPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H
 		"A_B_C_D_E_F_G_H",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -870,6 +959,7 @@ func (n *A_B_C_D_E_F_G_HPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -880,6 +970,8 @@ func (n *A_B_C_D_E_F_G_HPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -887,6 +979,7 @@ func (n *A_B_C_D_E_F_G_HPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -896,6 +989,8 @@ func (n *A_B_C_D_E_F_G_HPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_
 		"A_B_C_D_E_F_G_H",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -903,6 +998,7 @@ func (n *A_B_C_D_E_F_G_HPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -955,6 +1051,8 @@ func (n *A_B_C_D_E_F_G_H_IPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -962,6 +1060,7 @@ func (n *A_B_C_D_E_F_G_H_IPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -971,6 +1070,8 @@ func (n *A_B_C_D_E_F_G_H_IPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G
 		"A_B_C_D_E_F_G_H_I",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -978,6 +1079,7 @@ func (n *A_B_C_D_E_F_G_H_IPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -988,6 +1090,8 @@ func (n *A_B_C_D_E_F_G_H_IPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -995,6 +1099,7 @@ func (n *A_B_C_D_E_F_G_H_IPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1004,6 +1109,8 @@ func (n *A_B_C_D_E_F_G_H_IPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_
 		"A_B_C_D_E_F_G_H_I",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1011,6 +1118,7 @@ func (n *A_B_C_D_E_F_G_H_IPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1063,6 +1171,8 @@ func (n *A_B_C_D_E_F_G_H_I_JPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1070,6 +1180,7 @@ func (n *A_B_C_D_E_F_G_H_I_JPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1079,6 +1190,8 @@ func (n *A_B_C_D_E_F_G_H_I_JPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F
 		"A_B_C_D_E_F_G_H_I_J",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1086,6 +1199,7 @@ func (n *A_B_C_D_E_F_G_H_I_JPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1096,6 +1210,8 @@ func (n *A_B_C_D_E_F_G_H_I_JPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1103,6 +1219,7 @@ func (n *A_B_C_D_E_F_G_H_I_JPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1112,6 +1229,8 @@ func (n *A_B_C_D_E_F_G_H_I_JPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_
 		"A_B_C_D_E_F_G_H_I_J",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1119,6 +1238,7 @@ func (n *A_B_C_D_E_F_G_H_I_JPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1171,6 +1291,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1178,6 +1300,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1187,6 +1310,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E
 		"A_B_C_D_E_F_G_H_I_J_K",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1194,6 +1319,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1204,6 +1330,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1211,6 +1339,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1220,6 +1349,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_
 		"A_B_C_D_E_F_G_H_I_J_K",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1227,6 +1358,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1279,6 +1411,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1286,6 +1420,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1295,6 +1430,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D
 		"A_B_C_D_E_F_G_H_I_J_K_L",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1302,6 +1439,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1312,6 +1450,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1319,6 +1459,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1328,6 +1469,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_
 		"A_B_C_D_E_F_G_H_I_J_K_L",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1335,6 +1478,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1471,6 +1615,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1478,6 +1624,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1487,6 +1634,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1494,6 +1643,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1504,6 +1654,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1511,6 +1663,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1520,6 +1673,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1527,5 +1682,6 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }

--- a/exampleoc/nested/nested-0.go
+++ b/exampleoc/nested/nested-0.go
@@ -86,11 +86,12 @@ func binarySliceToFloatSlice(in []oc.Binary) []float32 {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *APath) State() ygnmi.SingletonQuery[*oc.A] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A](
+	return ygnmi.NewSingletonQuery[*oc.A](
 		"A",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -101,14 +102,17 @@ func (n *APath) State() ygnmi.SingletonQuery[*oc.A] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *APathAny) State() ygnmi.WildcardQuery[*oc.A] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A](
+	return ygnmi.NewWildcardQuery[*oc.A](
 		"A",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -125,11 +129,12 @@ func (n *APathAny) State() ygnmi.WildcardQuery[*oc.A] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *APath) Config() ygnmi.ConfigQuery[*oc.A] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A](
+	return ygnmi.NewConfigQuery[*oc.A](
 		"A",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -140,13 +145,16 @@ func (n *APath) Config() ygnmi.ConfigQuery[*oc.A] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *APathAny) Config() ygnmi.WildcardQuery[*oc.A] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A](
+	return ygnmi.NewWildcardQuery[*oc.A](
 		"A",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -206,11 +214,12 @@ func (n *A_BPathAny) C() *A_B_CPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_BPath) State() ygnmi.SingletonQuery[*oc.A_B] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B](
+	return ygnmi.NewSingletonQuery[*oc.A_B](
 		"A_B",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -221,14 +230,17 @@ func (n *A_BPath) State() ygnmi.SingletonQuery[*oc.A_B] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_BPathAny) State() ygnmi.WildcardQuery[*oc.A_B] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B](
+	return ygnmi.NewWildcardQuery[*oc.A_B](
 		"A_B",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -245,11 +257,12 @@ func (n *A_BPathAny) State() ygnmi.WildcardQuery[*oc.A_B] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_BPath) Config() ygnmi.ConfigQuery[*oc.A_B] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B](
+	return ygnmi.NewConfigQuery[*oc.A_B](
 		"A_B",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -260,13 +273,16 @@ func (n *A_BPath) Config() ygnmi.ConfigQuery[*oc.A_B] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_BPathAny) Config() ygnmi.WildcardQuery[*oc.A_B] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B](
+	return ygnmi.NewWildcardQuery[*oc.A_B](
 		"A_B",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -326,11 +342,12 @@ func (n *A_B_CPathAny) D() *A_B_C_DPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_CPath) State() ygnmi.SingletonQuery[*oc.A_B_C] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C](
 		"A_B_C",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -341,14 +358,17 @@ func (n *A_B_CPath) State() ygnmi.SingletonQuery[*oc.A_B_C] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_CPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C](
 		"A_B_C",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -365,11 +385,12 @@ func (n *A_B_CPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_CPath) Config() ygnmi.ConfigQuery[*oc.A_B_C] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C](
+	return ygnmi.NewConfigQuery[*oc.A_B_C](
 		"A_B_C",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -380,13 +401,16 @@ func (n *A_B_CPath) Config() ygnmi.ConfigQuery[*oc.A_B_C] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_CPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C](
 		"A_B_C",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -446,11 +470,12 @@ func (n *A_B_C_DPathAny) E() *A_B_C_D_EPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_DPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D](
 		"A_B_C_D",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -461,14 +486,17 @@ func (n *A_B_C_DPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_DPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D](
 		"A_B_C_D",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -485,11 +513,12 @@ func (n *A_B_C_DPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_DPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D](
 		"A_B_C_D",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -500,13 +529,16 @@ func (n *A_B_C_DPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_DPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D](
 		"A_B_C_D",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -566,11 +598,12 @@ func (n *A_B_C_D_EPathAny) F() *A_B_C_D_E_FPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_EPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E](
 		"A_B_C_D_E",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -581,14 +614,17 @@ func (n *A_B_C_D_EPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_EPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E](
 		"A_B_C_D_E",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -605,11 +641,12 @@ func (n *A_B_C_D_EPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_EPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E](
 		"A_B_C_D_E",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -620,13 +657,16 @@ func (n *A_B_C_D_EPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_EPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E](
 		"A_B_C_D_E",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -686,11 +726,12 @@ func (n *A_B_C_D_E_FPathAny) G() *A_B_C_D_E_F_GPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_FPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F](
 		"A_B_C_D_E_F",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -701,14 +742,17 @@ func (n *A_B_C_D_E_FPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_FPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F](
 		"A_B_C_D_E_F",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -725,11 +769,12 @@ func (n *A_B_C_D_E_FPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_FPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F](
 		"A_B_C_D_E_F",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -740,13 +785,16 @@ func (n *A_B_C_D_E_FPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_FPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F](
 		"A_B_C_D_E_F",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -806,11 +854,12 @@ func (n *A_B_C_D_E_F_GPathAny) H() *A_B_C_D_E_F_G_HPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_GPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G](
 		"A_B_C_D_E_F_G",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -821,14 +870,17 @@ func (n *A_B_C_D_E_F_GPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_GPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G](
 		"A_B_C_D_E_F_G",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -845,11 +897,12 @@ func (n *A_B_C_D_E_F_GPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_GPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G](
 		"A_B_C_D_E_F_G",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -860,13 +913,16 @@ func (n *A_B_C_D_E_F_GPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_GPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G](
 		"A_B_C_D_E_F_G",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -926,11 +982,12 @@ func (n *A_B_C_D_E_F_G_HPathAny) I() *A_B_C_D_E_F_G_H_IPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_HPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G_H](
 		"A_B_C_D_E_F_G_H",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -941,14 +998,17 @@ func (n *A_B_C_D_E_F_G_HPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H] 
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_HPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H](
 		"A_B_C_D_E_F_G_H",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -965,11 +1025,12 @@ func (n *A_B_C_D_E_F_G_HPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_HPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G_H](
 		"A_B_C_D_E_F_G_H",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -980,13 +1041,16 @@ func (n *A_B_C_D_E_F_G_HPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_HPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H](
 		"A_B_C_D_E_F_G_H",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -1046,11 +1110,12 @@ func (n *A_B_C_D_E_F_G_H_IPathAny) J() *A_B_C_D_E_F_G_H_I_JPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_IPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H_I] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H_I](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G_H_I](
 		"A_B_C_D_E_F_G_H_I",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1061,14 +1126,17 @@ func (n *A_B_C_D_E_F_G_H_IPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_IPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I](
 		"A_B_C_D_E_F_G_H_I",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -1085,11 +1153,12 @@ func (n *A_B_C_D_E_F_G_H_IPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_IPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H_I](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G_H_I](
 		"A_B_C_D_E_F_G_H_I",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1100,13 +1169,16 @@ func (n *A_B_C_D_E_F_G_H_IPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_IPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I](
 		"A_B_C_D_E_F_G_H_I",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -1166,11 +1238,12 @@ func (n *A_B_C_D_E_F_G_H_I_JPathAny) K() *A_B_C_D_E_F_G_H_I_J_KPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_JPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J](
 		"A_B_C_D_E_F_G_H_I_J",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1181,14 +1254,17 @@ func (n *A_B_C_D_E_F_G_H_I_JPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_JPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J](
 		"A_B_C_D_E_F_G_H_I_J",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -1205,11 +1281,12 @@ func (n *A_B_C_D_E_F_G_H_I_JPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_JPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J](
 		"A_B_C_D_E_F_G_H_I_J",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1220,13 +1297,16 @@ func (n *A_B_C_D_E_F_G_H_I_JPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_JPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J](
 		"A_B_C_D_E_F_G_H_I_J",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -1286,11 +1366,12 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPathAny) L() *A_B_C_D_E_F_G_H_I_J_K_LPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_KPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
 		"A_B_C_D_E_F_G_H_I_J_K",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1301,14 +1382,17 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_KPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
 		"A_B_C_D_E_F_G_H_I_J_K",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -1325,11 +1409,12 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_KPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
 		"A_B_C_D_E_F_G_H_I_J_K",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1340,13 +1425,16 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_KPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
 		"A_B_C_D_E_F_G_H_I_J_K",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -1406,11 +1494,12 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPathAny) M() *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_LPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
 		"A_B_C_D_E_F_G_H_I_J_K_L",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1421,14 +1510,17 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_LPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
 		"A_B_C_D_E_F_G_H_I_J_K_L",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -1445,11 +1537,12 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_LPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
 		"A_B_C_D_E_F_G_H_I_J_K_L",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1460,13 +1553,16 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_LPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
 		"A_B_C_D_E_F_G_H_I_J_K_L",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -1501,8 +1597,9 @@ type A_B_C_D_E_F_G_H_I_J_K_L_M_FooPathAny struct {
 //	Path from parent:     "state/foo"
 //	Path from root:       "/a/b/c/d/e/f/g/h/i/j/k/l/m/state/foo"
 func (n *A_B_C_D_E_F_G_H_I_J_K_L_M_FooPath) State() ygnmi.SingletonQuery[string] {
-	return ygnmi.NewLeafSingletonQuery[string](
+	return ygnmi.NewSingletonQuery[string](
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1526,6 +1623,8 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_M_FooPath) State() ygnmi.SingletonQuery[string]
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -1536,8 +1635,9 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_M_FooPath) State() ygnmi.SingletonQuery[string]
 //	Path from parent:     "state/foo"
 //	Path from root:       "/a/b/c/d/e/f/g/h/i/j/k/l/m/state/foo"
 func (n *A_B_C_D_E_F_G_H_I_J_K_L_M_FooPathAny) State() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1561,6 +1661,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_M_FooPathAny) State() ygnmi.WildcardQuery[strin
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1610,11 +1711,12 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) Foo() *A_B_C_D_E_F_G_H_I_J_K_L_M_FooP
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1625,14 +1727,17 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -1649,11 +1754,12 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1664,13 +1770,16 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
+		false,
+		false,
 		false,
 		n,
 		nil,

--- a/exampleoc/simple/simple-0.go
+++ b/exampleoc/simple/simple-0.go
@@ -88,11 +88,12 @@ func binarySliceToFloatSlice(in []oc.Binary) []float32 {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *ParentPath) State() ygnmi.SingletonQuery[*oc.Parent] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Parent](
+	return ygnmi.NewSingletonQuery[*oc.Parent](
 		"Parent",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -103,14 +104,17 @@ func (n *ParentPath) State() ygnmi.SingletonQuery[*oc.Parent] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *ParentPathAny) State() ygnmi.WildcardQuery[*oc.Parent] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Parent](
+	return ygnmi.NewWildcardQuery[*oc.Parent](
 		"Parent",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -127,11 +131,12 @@ func (n *ParentPathAny) State() ygnmi.WildcardQuery[*oc.Parent] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *ParentPath) Config() ygnmi.ConfigQuery[*oc.Parent] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Parent](
+	return ygnmi.NewConfigQuery[*oc.Parent](
 		"Parent",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -142,13 +147,16 @@ func (n *ParentPath) Config() ygnmi.ConfigQuery[*oc.Parent] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *ParentPathAny) Config() ygnmi.WildcardQuery[*oc.Parent] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Parent](
+	return ygnmi.NewWildcardQuery[*oc.Parent](
 		"Parent",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -183,8 +191,9 @@ type Parent_Child_FivePathAny struct {
 //	Path from parent:     "state/five"
 //	Path from root:       "/parent/child/state/five"
 func (n *Parent_Child_FivePath) State() ygnmi.SingletonQuery[float32] {
-	return ygnmi.NewLeafSingletonQuery[float32](
+	return ygnmi.NewSingletonQuery[float32](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -204,6 +213,8 @@ func (n *Parent_Child_FivePath) State() ygnmi.SingletonQuery[float32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -214,8 +225,9 @@ func (n *Parent_Child_FivePath) State() ygnmi.SingletonQuery[float32] {
 //	Path from parent:     "state/five"
 //	Path from root:       "/parent/child/state/five"
 func (n *Parent_Child_FivePathAny) State() ygnmi.WildcardQuery[float32] {
-	return ygnmi.NewLeafWildcardQuery[float32](
+	return ygnmi.NewWildcardQuery[float32](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -235,6 +247,7 @@ func (n *Parent_Child_FivePathAny) State() ygnmi.WildcardQuery[float32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -245,9 +258,10 @@ func (n *Parent_Child_FivePathAny) State() ygnmi.WildcardQuery[float32] {
 //	Path from parent:     "config/five"
 //	Path from root:       "/parent/child/config/five"
 func (n *Parent_Child_FivePath) Config() ygnmi.ConfigQuery[float32] {
-	return ygnmi.NewLeafConfigQuery[float32](
+	return ygnmi.NewConfigQuery[float32](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "five"},
@@ -266,6 +280,8 @@ func (n *Parent_Child_FivePath) Config() ygnmi.ConfigQuery[float32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -276,9 +292,10 @@ func (n *Parent_Child_FivePath) Config() ygnmi.ConfigQuery[float32] {
 //	Path from parent:     "config/five"
 //	Path from root:       "/parent/child/config/five"
 func (n *Parent_Child_FivePathAny) Config() ygnmi.WildcardQuery[float32] {
-	return ygnmi.NewLeafWildcardQuery[float32](
+	return ygnmi.NewWildcardQuery[float32](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "five"},
@@ -297,6 +314,7 @@ func (n *Parent_Child_FivePathAny) Config() ygnmi.WildcardQuery[float32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -319,8 +337,9 @@ type Parent_Child_FourPathAny struct {
 //	Path from parent:     "state/four"
 //	Path from root:       "/parent/child/state/four"
 func (n *Parent_Child_FourPath) State() ygnmi.SingletonQuery[oc.Binary] {
-	return ygnmi.NewLeafSingletonQuery[oc.Binary](
+	return ygnmi.NewSingletonQuery[oc.Binary](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -340,6 +359,8 @@ func (n *Parent_Child_FourPath) State() ygnmi.SingletonQuery[oc.Binary] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -350,8 +371,9 @@ func (n *Parent_Child_FourPath) State() ygnmi.SingletonQuery[oc.Binary] {
 //	Path from parent:     "state/four"
 //	Path from root:       "/parent/child/state/four"
 func (n *Parent_Child_FourPathAny) State() ygnmi.WildcardQuery[oc.Binary] {
-	return ygnmi.NewLeafWildcardQuery[oc.Binary](
+	return ygnmi.NewWildcardQuery[oc.Binary](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -371,6 +393,7 @@ func (n *Parent_Child_FourPathAny) State() ygnmi.WildcardQuery[oc.Binary] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -381,9 +404,10 @@ func (n *Parent_Child_FourPathAny) State() ygnmi.WildcardQuery[oc.Binary] {
 //	Path from parent:     "config/four"
 //	Path from root:       "/parent/child/config/four"
 func (n *Parent_Child_FourPath) Config() ygnmi.ConfigQuery[oc.Binary] {
-	return ygnmi.NewLeafConfigQuery[oc.Binary](
+	return ygnmi.NewConfigQuery[oc.Binary](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "four"},
@@ -402,6 +426,8 @@ func (n *Parent_Child_FourPath) Config() ygnmi.ConfigQuery[oc.Binary] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -412,9 +438,10 @@ func (n *Parent_Child_FourPath) Config() ygnmi.ConfigQuery[oc.Binary] {
 //	Path from parent:     "config/four"
 //	Path from root:       "/parent/child/config/four"
 func (n *Parent_Child_FourPathAny) Config() ygnmi.WildcardQuery[oc.Binary] {
-	return ygnmi.NewLeafWildcardQuery[oc.Binary](
+	return ygnmi.NewWildcardQuery[oc.Binary](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "four"},
@@ -433,6 +460,7 @@ func (n *Parent_Child_FourPathAny) Config() ygnmi.WildcardQuery[oc.Binary] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -455,8 +483,9 @@ type Parent_Child_OnePathAny struct {
 //	Path from parent:     "state/one"
 //	Path from root:       "/parent/child/state/one"
 func (n *Parent_Child_OnePath) State() ygnmi.SingletonQuery[string] {
-	return ygnmi.NewLeafSingletonQuery[string](
+	return ygnmi.NewSingletonQuery[string](
 		"Parent_Child",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -480,6 +509,8 @@ func (n *Parent_Child_OnePath) State() ygnmi.SingletonQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -490,8 +521,9 @@ func (n *Parent_Child_OnePath) State() ygnmi.SingletonQuery[string] {
 //	Path from parent:     "state/one"
 //	Path from root:       "/parent/child/state/one"
 func (n *Parent_Child_OnePathAny) State() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"Parent_Child",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -515,6 +547,7 @@ func (n *Parent_Child_OnePathAny) State() ygnmi.WildcardQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -525,9 +558,10 @@ func (n *Parent_Child_OnePathAny) State() ygnmi.WildcardQuery[string] {
 //	Path from parent:     "config/one"
 //	Path from root:       "/parent/child/config/one"
 func (n *Parent_Child_OnePath) Config() ygnmi.ConfigQuery[string] {
-	return ygnmi.NewLeafConfigQuery[string](
+	return ygnmi.NewConfigQuery[string](
 		"Parent_Child",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "one"},
@@ -550,6 +584,8 @@ func (n *Parent_Child_OnePath) Config() ygnmi.ConfigQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -560,9 +596,10 @@ func (n *Parent_Child_OnePath) Config() ygnmi.ConfigQuery[string] {
 //	Path from parent:     "config/one"
 //	Path from root:       "/parent/child/config/one"
 func (n *Parent_Child_OnePathAny) Config() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"Parent_Child",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "one"},
@@ -585,6 +622,7 @@ func (n *Parent_Child_OnePathAny) Config() ygnmi.WildcardQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -607,8 +645,9 @@ type Parent_Child_SixPathAny struct {
 //	Path from parent:     "state/six"
 //	Path from root:       "/parent/child/state/six"
 func (n *Parent_Child_SixPath) State() ygnmi.SingletonQuery[[]float32] {
-	return ygnmi.NewLeafSingletonQuery[[]float32](
+	return ygnmi.NewSingletonQuery[[]float32](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -628,6 +667,8 @@ func (n *Parent_Child_SixPath) State() ygnmi.SingletonQuery[[]float32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -638,8 +679,9 @@ func (n *Parent_Child_SixPath) State() ygnmi.SingletonQuery[[]float32] {
 //	Path from parent:     "state/six"
 //	Path from root:       "/parent/child/state/six"
 func (n *Parent_Child_SixPathAny) State() ygnmi.WildcardQuery[[]float32] {
-	return ygnmi.NewLeafWildcardQuery[[]float32](
+	return ygnmi.NewWildcardQuery[[]float32](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -659,6 +701,7 @@ func (n *Parent_Child_SixPathAny) State() ygnmi.WildcardQuery[[]float32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -669,9 +712,10 @@ func (n *Parent_Child_SixPathAny) State() ygnmi.WildcardQuery[[]float32] {
 //	Path from parent:     "config/six"
 //	Path from root:       "/parent/child/config/six"
 func (n *Parent_Child_SixPath) Config() ygnmi.ConfigQuery[[]float32] {
-	return ygnmi.NewLeafConfigQuery[[]float32](
+	return ygnmi.NewConfigQuery[[]float32](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "six"},
@@ -690,6 +734,8 @@ func (n *Parent_Child_SixPath) Config() ygnmi.ConfigQuery[[]float32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -700,9 +746,10 @@ func (n *Parent_Child_SixPath) Config() ygnmi.ConfigQuery[[]float32] {
 //	Path from parent:     "config/six"
 //	Path from root:       "/parent/child/config/six"
 func (n *Parent_Child_SixPathAny) Config() ygnmi.WildcardQuery[[]float32] {
-	return ygnmi.NewLeafWildcardQuery[[]float32](
+	return ygnmi.NewWildcardQuery[[]float32](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "six"},
@@ -721,6 +768,7 @@ func (n *Parent_Child_SixPathAny) Config() ygnmi.WildcardQuery[[]float32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -743,8 +791,9 @@ type Parent_Child_ThreePathAny struct {
 //	Path from parent:     "state/three"
 //	Path from root:       "/parent/child/state/three"
 func (n *Parent_Child_ThreePath) State() ygnmi.SingletonQuery[oc.E_Child_Three] {
-	return ygnmi.NewLeafSingletonQuery[oc.E_Child_Three](
+	return ygnmi.NewSingletonQuery[oc.E_Child_Three](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -764,6 +813,8 @@ func (n *Parent_Child_ThreePath) State() ygnmi.SingletonQuery[oc.E_Child_Three] 
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -774,8 +825,9 @@ func (n *Parent_Child_ThreePath) State() ygnmi.SingletonQuery[oc.E_Child_Three] 
 //	Path from parent:     "state/three"
 //	Path from root:       "/parent/child/state/three"
 func (n *Parent_Child_ThreePathAny) State() ygnmi.WildcardQuery[oc.E_Child_Three] {
-	return ygnmi.NewLeafWildcardQuery[oc.E_Child_Three](
+	return ygnmi.NewWildcardQuery[oc.E_Child_Three](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -795,6 +847,7 @@ func (n *Parent_Child_ThreePathAny) State() ygnmi.WildcardQuery[oc.E_Child_Three
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -805,9 +858,10 @@ func (n *Parent_Child_ThreePathAny) State() ygnmi.WildcardQuery[oc.E_Child_Three
 //	Path from parent:     "config/three"
 //	Path from root:       "/parent/child/config/three"
 func (n *Parent_Child_ThreePath) Config() ygnmi.ConfigQuery[oc.E_Child_Three] {
-	return ygnmi.NewLeafConfigQuery[oc.E_Child_Three](
+	return ygnmi.NewConfigQuery[oc.E_Child_Three](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "three"},
@@ -826,6 +880,8 @@ func (n *Parent_Child_ThreePath) Config() ygnmi.ConfigQuery[oc.E_Child_Three] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -836,9 +892,10 @@ func (n *Parent_Child_ThreePath) Config() ygnmi.ConfigQuery[oc.E_Child_Three] {
 //	Path from parent:     "config/three"
 //	Path from root:       "/parent/child/config/three"
 func (n *Parent_Child_ThreePathAny) Config() ygnmi.WildcardQuery[oc.E_Child_Three] {
-	return ygnmi.NewLeafWildcardQuery[oc.E_Child_Three](
+	return ygnmi.NewWildcardQuery[oc.E_Child_Three](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "three"},
@@ -857,6 +914,7 @@ func (n *Parent_Child_ThreePathAny) Config() ygnmi.WildcardQuery[oc.E_Child_Thre
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -879,8 +937,9 @@ type Parent_Child_TwoPathAny struct {
 //	Path from parent:     "state/two"
 //	Path from root:       "/parent/child/state/two"
 func (n *Parent_Child_TwoPath) State() ygnmi.SingletonQuery[string] {
-	return ygnmi.NewLeafSingletonQuery[string](
+	return ygnmi.NewSingletonQuery[string](
 		"Parent_Child",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -904,6 +963,8 @@ func (n *Parent_Child_TwoPath) State() ygnmi.SingletonQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -914,8 +975,9 @@ func (n *Parent_Child_TwoPath) State() ygnmi.SingletonQuery[string] {
 //	Path from parent:     "state/two"
 //	Path from root:       "/parent/child/state/two"
 func (n *Parent_Child_TwoPathAny) State() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"Parent_Child",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -939,6 +1001,7 @@ func (n *Parent_Child_TwoPathAny) State() ygnmi.WildcardQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1158,11 +1221,12 @@ func (n *Parent_ChildPathAny) Two() *Parent_Child_TwoPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Parent_ChildPath) State() ygnmi.SingletonQuery[*oc.Parent_Child] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Parent_Child](
+	return ygnmi.NewSingletonQuery[*oc.Parent_Child](
 		"Parent_Child",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1173,14 +1237,17 @@ func (n *Parent_ChildPath) State() ygnmi.SingletonQuery[*oc.Parent_Child] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Parent_ChildPathAny) State() ygnmi.WildcardQuery[*oc.Parent_Child] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Parent_Child](
+	return ygnmi.NewWildcardQuery[*oc.Parent_Child](
 		"Parent_Child",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -1197,11 +1264,12 @@ func (n *Parent_ChildPathAny) State() ygnmi.WildcardQuery[*oc.Parent_Child] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Parent_ChildPath) Config() ygnmi.ConfigQuery[*oc.Parent_Child] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Parent_Child](
+	return ygnmi.NewConfigQuery[*oc.Parent_Child](
 		"Parent_Child",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1212,13 +1280,16 @@ func (n *Parent_ChildPath) Config() ygnmi.ConfigQuery[*oc.Parent_Child] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Parent_ChildPathAny) Config() ygnmi.WildcardQuery[*oc.Parent_Child] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Parent_Child](
+	return ygnmi.NewWildcardQuery[*oc.Parent_Child](
 		"Parent_Child",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -1253,8 +1324,9 @@ type RemoteContainer_ALeafPathAny struct {
 //	Path from parent:     "state/a-leaf"
 //	Path from root:       "/remote-container/state/a-leaf"
 func (n *RemoteContainer_ALeafPath) State() ygnmi.SingletonQuery[string] {
-	return ygnmi.NewLeafSingletonQuery[string](
+	return ygnmi.NewSingletonQuery[string](
 		"RemoteContainer",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1278,6 +1350,8 @@ func (n *RemoteContainer_ALeafPath) State() ygnmi.SingletonQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -1288,8 +1362,9 @@ func (n *RemoteContainer_ALeafPath) State() ygnmi.SingletonQuery[string] {
 //	Path from parent:     "state/a-leaf"
 //	Path from root:       "/remote-container/state/a-leaf"
 func (n *RemoteContainer_ALeafPathAny) State() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"RemoteContainer",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1313,6 +1388,7 @@ func (n *RemoteContainer_ALeafPathAny) State() ygnmi.WildcardQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1323,9 +1399,10 @@ func (n *RemoteContainer_ALeafPathAny) State() ygnmi.WildcardQuery[string] {
 //	Path from parent:     "config/a-leaf"
 //	Path from root:       "/remote-container/config/a-leaf"
 func (n *RemoteContainer_ALeafPath) Config() ygnmi.ConfigQuery[string] {
-	return ygnmi.NewLeafConfigQuery[string](
+	return ygnmi.NewConfigQuery[string](
 		"RemoteContainer",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "a-leaf"},
@@ -1348,6 +1425,8 @@ func (n *RemoteContainer_ALeafPath) Config() ygnmi.ConfigQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -1358,9 +1437,10 @@ func (n *RemoteContainer_ALeafPath) Config() ygnmi.ConfigQuery[string] {
 //	Path from parent:     "config/a-leaf"
 //	Path from root:       "/remote-container/config/a-leaf"
 func (n *RemoteContainer_ALeafPathAny) Config() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"RemoteContainer",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "a-leaf"},
@@ -1383,6 +1463,7 @@ func (n *RemoteContainer_ALeafPathAny) Config() ygnmi.WildcardQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1432,11 +1513,12 @@ func (n *RemoteContainerPathAny) ALeaf() *RemoteContainer_ALeafPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *RemoteContainerPath) State() ygnmi.SingletonQuery[*oc.RemoteContainer] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.RemoteContainer](
+	return ygnmi.NewSingletonQuery[*oc.RemoteContainer](
 		"RemoteContainer",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1447,14 +1529,17 @@ func (n *RemoteContainerPath) State() ygnmi.SingletonQuery[*oc.RemoteContainer] 
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *RemoteContainerPathAny) State() ygnmi.WildcardQuery[*oc.RemoteContainer] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.RemoteContainer](
+	return ygnmi.NewWildcardQuery[*oc.RemoteContainer](
 		"RemoteContainer",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -1471,11 +1556,12 @@ func (n *RemoteContainerPathAny) State() ygnmi.WildcardQuery[*oc.RemoteContainer
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *RemoteContainerPath) Config() ygnmi.ConfigQuery[*oc.RemoteContainer] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.RemoteContainer](
+	return ygnmi.NewConfigQuery[*oc.RemoteContainer](
 		"RemoteContainer",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1486,13 +1572,16 @@ func (n *RemoteContainerPath) Config() ygnmi.ConfigQuery[*oc.RemoteContainer] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *RemoteContainerPathAny) Config() ygnmi.WildcardQuery[*oc.RemoteContainer] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.RemoteContainer](
+	return ygnmi.NewWildcardQuery[*oc.RemoteContainer](
 		"RemoteContainer",
+		false,
+		false,
 		false,
 		n,
 		nil,

--- a/exampleoc/simple/simple-0.go
+++ b/exampleoc/simple/simple-0.go
@@ -93,6 +93,8 @@ func (n *ParentPath) State() ygnmi.SingletonQuery[*oc.Parent] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -100,6 +102,7 @@ func (n *ParentPath) State() ygnmi.SingletonQuery[*oc.Parent] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -109,6 +112,8 @@ func (n *ParentPathAny) State() ygnmi.WildcardQuery[*oc.Parent] {
 		"Parent",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -116,6 +121,7 @@ func (n *ParentPathAny) State() ygnmi.WildcardQuery[*oc.Parent] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -126,6 +132,8 @@ func (n *ParentPath) Config() ygnmi.ConfigQuery[*oc.Parent] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -133,6 +141,7 @@ func (n *ParentPath) Config() ygnmi.ConfigQuery[*oc.Parent] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -142,6 +151,8 @@ func (n *ParentPathAny) Config() ygnmi.WildcardQuery[*oc.Parent] {
 		"Parent",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -149,6 +160,7 @@ func (n *ParentPathAny) Config() ygnmi.WildcardQuery[*oc.Parent] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1151,6 +1163,8 @@ func (n *Parent_ChildPath) State() ygnmi.SingletonQuery[*oc.Parent_Child] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1158,6 +1172,7 @@ func (n *Parent_ChildPath) State() ygnmi.SingletonQuery[*oc.Parent_Child] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1167,6 +1182,8 @@ func (n *Parent_ChildPathAny) State() ygnmi.WildcardQuery[*oc.Parent_Child] {
 		"Parent_Child",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1174,6 +1191,7 @@ func (n *Parent_ChildPathAny) State() ygnmi.WildcardQuery[*oc.Parent_Child] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1184,6 +1202,8 @@ func (n *Parent_ChildPath) Config() ygnmi.ConfigQuery[*oc.Parent_Child] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1191,6 +1211,7 @@ func (n *Parent_ChildPath) Config() ygnmi.ConfigQuery[*oc.Parent_Child] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1200,6 +1221,8 @@ func (n *Parent_ChildPathAny) Config() ygnmi.WildcardQuery[*oc.Parent_Child] {
 		"Parent_Child",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1207,6 +1230,7 @@ func (n *Parent_ChildPathAny) Config() ygnmi.WildcardQuery[*oc.Parent_Child] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1413,6 +1437,8 @@ func (n *RemoteContainerPath) State() ygnmi.SingletonQuery[*oc.RemoteContainer] 
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1420,6 +1446,7 @@ func (n *RemoteContainerPath) State() ygnmi.SingletonQuery[*oc.RemoteContainer] 
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1429,6 +1456,8 @@ func (n *RemoteContainerPathAny) State() ygnmi.WildcardQuery[*oc.RemoteContainer
 		"RemoteContainer",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1436,6 +1465,7 @@ func (n *RemoteContainerPathAny) State() ygnmi.WildcardQuery[*oc.RemoteContainer
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1446,6 +1476,8 @@ func (n *RemoteContainerPath) Config() ygnmi.ConfigQuery[*oc.RemoteContainer] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1453,6 +1485,7 @@ func (n *RemoteContainerPath) Config() ygnmi.ConfigQuery[*oc.RemoteContainer] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1462,6 +1495,8 @@ func (n *RemoteContainerPathAny) Config() ygnmi.WildcardQuery[*oc.RemoteContaine
 		"RemoteContainer",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1469,5 +1504,6 @@ func (n *RemoteContainerPathAny) Config() ygnmi.WildcardQuery[*oc.RemoteContaine
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }

--- a/exampleoc/withlistval/withlistval-0.go
+++ b/exampleoc/withlistval/withlistval-0.go
@@ -270,11 +270,12 @@ func binarySliceToFloatSlice(in []oc.Binary) []float32 {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *ModelPath) State() ygnmi.SingletonQuery[*oc.Model] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model](
+	return ygnmi.NewSingletonQuery[*oc.Model](
 		"Model",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -285,14 +286,17 @@ func (n *ModelPath) State() ygnmi.SingletonQuery[*oc.Model] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *ModelPathAny) State() ygnmi.WildcardQuery[*oc.Model] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model](
+	return ygnmi.NewWildcardQuery[*oc.Model](
 		"Model",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -309,11 +313,12 @@ func (n *ModelPathAny) State() ygnmi.WildcardQuery[*oc.Model] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *ModelPath) Config() ygnmi.ConfigQuery[*oc.Model] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Model](
+	return ygnmi.NewConfigQuery[*oc.Model](
 		"Model",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -324,13 +329,16 @@ func (n *ModelPath) Config() ygnmi.ConfigQuery[*oc.Model] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *ModelPathAny) Config() ygnmi.WildcardQuery[*oc.Model] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model](
+	return ygnmi.NewWildcardQuery[*oc.Model](
 		"Model",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -365,8 +373,9 @@ type Model_MultiKey_Key1PathAny struct {
 //	Path from parent:     "state/key1"
 //	Path from root:       "/model/b/multi-key/state/key1"
 func (n *Model_MultiKey_Key1Path) State() ygnmi.SingletonQuery[uint32] {
-	return ygnmi.NewLeafSingletonQuery[uint32](
+	return ygnmi.NewSingletonQuery[uint32](
 		"Model_MultiKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -390,6 +399,8 @@ func (n *Model_MultiKey_Key1Path) State() ygnmi.SingletonQuery[uint32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -400,8 +411,9 @@ func (n *Model_MultiKey_Key1Path) State() ygnmi.SingletonQuery[uint32] {
 //	Path from parent:     "state/key1"
 //	Path from root:       "/model/b/multi-key/state/key1"
 func (n *Model_MultiKey_Key1PathAny) State() ygnmi.WildcardQuery[uint32] {
-	return ygnmi.NewLeafWildcardQuery[uint32](
+	return ygnmi.NewWildcardQuery[uint32](
 		"Model_MultiKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -425,6 +437,7 @@ func (n *Model_MultiKey_Key1PathAny) State() ygnmi.WildcardQuery[uint32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -435,9 +448,10 @@ func (n *Model_MultiKey_Key1PathAny) State() ygnmi.WildcardQuery[uint32] {
 //	Path from parent:     "config/key1"
 //	Path from root:       "/model/b/multi-key/config/key1"
 func (n *Model_MultiKey_Key1Path) Config() ygnmi.ConfigQuery[uint32] {
-	return ygnmi.NewLeafConfigQuery[uint32](
+	return ygnmi.NewConfigQuery[uint32](
 		"Model_MultiKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "key1"},
@@ -460,6 +474,8 @@ func (n *Model_MultiKey_Key1Path) Config() ygnmi.ConfigQuery[uint32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -470,9 +486,10 @@ func (n *Model_MultiKey_Key1Path) Config() ygnmi.ConfigQuery[uint32] {
 //	Path from parent:     "config/key1"
 //	Path from root:       "/model/b/multi-key/config/key1"
 func (n *Model_MultiKey_Key1PathAny) Config() ygnmi.WildcardQuery[uint32] {
-	return ygnmi.NewLeafWildcardQuery[uint32](
+	return ygnmi.NewWildcardQuery[uint32](
 		"Model_MultiKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "key1"},
@@ -495,6 +512,7 @@ func (n *Model_MultiKey_Key1PathAny) Config() ygnmi.WildcardQuery[uint32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -517,8 +535,9 @@ type Model_MultiKey_Key2PathAny struct {
 //	Path from parent:     "state/key2"
 //	Path from root:       "/model/b/multi-key/state/key2"
 func (n *Model_MultiKey_Key2Path) State() ygnmi.SingletonQuery[uint64] {
-	return ygnmi.NewLeafSingletonQuery[uint64](
+	return ygnmi.NewSingletonQuery[uint64](
 		"Model_MultiKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -542,6 +561,8 @@ func (n *Model_MultiKey_Key2Path) State() ygnmi.SingletonQuery[uint64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -552,8 +573,9 @@ func (n *Model_MultiKey_Key2Path) State() ygnmi.SingletonQuery[uint64] {
 //	Path from parent:     "state/key2"
 //	Path from root:       "/model/b/multi-key/state/key2"
 func (n *Model_MultiKey_Key2PathAny) State() ygnmi.WildcardQuery[uint64] {
-	return ygnmi.NewLeafWildcardQuery[uint64](
+	return ygnmi.NewWildcardQuery[uint64](
 		"Model_MultiKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -577,6 +599,7 @@ func (n *Model_MultiKey_Key2PathAny) State() ygnmi.WildcardQuery[uint64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -587,9 +610,10 @@ func (n *Model_MultiKey_Key2PathAny) State() ygnmi.WildcardQuery[uint64] {
 //	Path from parent:     "config/key2"
 //	Path from root:       "/model/b/multi-key/config/key2"
 func (n *Model_MultiKey_Key2Path) Config() ygnmi.ConfigQuery[uint64] {
-	return ygnmi.NewLeafConfigQuery[uint64](
+	return ygnmi.NewConfigQuery[uint64](
 		"Model_MultiKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "key2"},
@@ -612,6 +636,8 @@ func (n *Model_MultiKey_Key2Path) Config() ygnmi.ConfigQuery[uint64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -622,9 +648,10 @@ func (n *Model_MultiKey_Key2Path) Config() ygnmi.ConfigQuery[uint64] {
 //	Path from parent:     "config/key2"
 //	Path from root:       "/model/b/multi-key/config/key2"
 func (n *Model_MultiKey_Key2PathAny) Config() ygnmi.WildcardQuery[uint64] {
-	return ygnmi.NewLeafWildcardQuery[uint64](
+	return ygnmi.NewWildcardQuery[uint64](
 		"Model_MultiKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "key2"},
@@ -647,6 +674,7 @@ func (n *Model_MultiKey_Key2PathAny) Config() ygnmi.WildcardQuery[uint64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -730,11 +758,12 @@ func (n *Model_MultiKeyPathAny) Key2() *Model_MultiKey_Key2PathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_MultiKeyPath) State() ygnmi.SingletonQuery[*oc.Model_MultiKey] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_MultiKey](
+	return ygnmi.NewSingletonQuery[*oc.Model_MultiKey](
 		"Model_MultiKey",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -745,14 +774,17 @@ func (n *Model_MultiKeyPath) State() ygnmi.SingletonQuery[*oc.Model_MultiKey] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_MultiKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_MultiKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_MultiKey](
+	return ygnmi.NewWildcardQuery[*oc.Model_MultiKey](
 		"Model_MultiKey",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -769,11 +801,12 @@ func (n *Model_MultiKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_MultiKey] 
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Model_MultiKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_MultiKey] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Model_MultiKey](
+	return ygnmi.NewConfigQuery[*oc.Model_MultiKey](
 		"Model_MultiKey",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -784,13 +817,16 @@ func (n *Model_MultiKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_MultiKey] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Model_MultiKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_MultiKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_MultiKey](
+	return ygnmi.NewWildcardQuery[*oc.Model_MultiKey](
 		"Model_MultiKey",
+		false,
+		false,
 		false,
 		n,
 		nil,
@@ -818,11 +854,12 @@ type Model_NoKeyPathAny struct {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_NoKeyPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_NoKey](
+	return ygnmi.NewSingletonQuery[*oc.Model_NoKey](
 		"Model_NoKey",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -833,14 +870,17 @@ func (n *Model_NoKeyPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_NoKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_NoKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_NoKey](
+	return ygnmi.NewWildcardQuery[*oc.Model_NoKey](
 		"Model_NoKey",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -874,8 +914,9 @@ type Model_NoKey_Foo_KeyPathAny struct {
 //	Path from parent:     "state/key"
 //	Path from root:       "/model/c/no-key/foo/state/key"
 func (n *Model_NoKey_Foo_KeyPath) State() ygnmi.SingletonQuery[string] {
-	return ygnmi.NewLeafSingletonQuery[string](
+	return ygnmi.NewSingletonQuery[string](
 		"Model_NoKey_Foo",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -899,6 +940,8 @@ func (n *Model_NoKey_Foo_KeyPath) State() ygnmi.SingletonQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -909,8 +952,9 @@ func (n *Model_NoKey_Foo_KeyPath) State() ygnmi.SingletonQuery[string] {
 //	Path from parent:     "state/key"
 //	Path from root:       "/model/c/no-key/foo/state/key"
 func (n *Model_NoKey_Foo_KeyPathAny) State() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"Model_NoKey_Foo",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -934,6 +978,7 @@ func (n *Model_NoKey_Foo_KeyPathAny) State() ygnmi.WildcardQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -956,8 +1001,9 @@ type Model_NoKey_Foo_ValuePathAny struct {
 //	Path from parent:     "state/value"
 //	Path from root:       "/model/c/no-key/foo/state/value"
 func (n *Model_NoKey_Foo_ValuePath) State() ygnmi.SingletonQuery[int64] {
-	return ygnmi.NewLeafSingletonQuery[int64](
+	return ygnmi.NewSingletonQuery[int64](
 		"Model_NoKey_Foo",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -981,6 +1027,8 @@ func (n *Model_NoKey_Foo_ValuePath) State() ygnmi.SingletonQuery[int64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -991,8 +1039,9 @@ func (n *Model_NoKey_Foo_ValuePath) State() ygnmi.SingletonQuery[int64] {
 //	Path from parent:     "state/value"
 //	Path from root:       "/model/c/no-key/foo/state/value"
 func (n *Model_NoKey_Foo_ValuePathAny) State() ygnmi.WildcardQuery[int64] {
-	return ygnmi.NewLeafWildcardQuery[int64](
+	return ygnmi.NewWildcardQuery[int64](
 		"Model_NoKey_Foo",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1016,6 +1065,7 @@ func (n *Model_NoKey_Foo_ValuePathAny) State() ygnmi.WildcardQuery[int64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1099,11 +1149,12 @@ func (n *Model_NoKey_FooPathAny) Value() *Model_NoKey_Foo_ValuePathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_NoKey_FooPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey_Foo] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_NoKey_Foo](
+	return ygnmi.NewSingletonQuery[*oc.Model_NoKey_Foo](
 		"Model_NoKey_Foo",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1114,14 +1165,17 @@ func (n *Model_NoKey_FooPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey_Foo] 
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_NoKey_FooPathAny) State() ygnmi.WildcardQuery[*oc.Model_NoKey_Foo] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_NoKey_Foo](
+	return ygnmi.NewWildcardQuery[*oc.Model_NoKey_Foo](
 		"Model_NoKey_Foo",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -1148,16 +1202,17 @@ type Model_OrderedListPathAny struct {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_OrderedListPath) State() ygnmi.SingletonQuery[*oc.Model_OrderedList_OrderedMap] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_OrderedList_OrderedMap](
+	return ygnmi.NewSingletonQuery[*oc.Model_OrderedList_OrderedMap](
 		"Model",
 		true,
+		false,
+		false,
 		n,
 		func(gs ygot.ValidatedGoStruct) (*oc.Model_OrderedList_OrderedMap, bool) {
 			ret := gs.(*oc.Model).OrderedList
 			return ret, ret != nil
 		},
 		func() ygot.ValidatedGoStruct { return new(oc.Model) },
-		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1165,6 +1220,7 @@ func (n *Model_OrderedListPath) State() ygnmi.SingletonQuery[*oc.Model_OrderedLi
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 		&ygnmi.CompressionInfo{
 			PreRelPath:  []string{"openconfig-withlistval:ordered-lists"},
 			PostRelPath: []string{"openconfig-withlistval:ordered-list"},
@@ -1174,9 +1230,11 @@ func (n *Model_OrderedListPath) State() ygnmi.SingletonQuery[*oc.Model_OrderedLi
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_OrderedListPathAny) State() ygnmi.WildcardQuery[*oc.Model_OrderedList_OrderedMap] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_OrderedList_OrderedMap](
+	return ygnmi.NewWildcardQuery[*oc.Model_OrderedList_OrderedMap](
 		"Model",
 		true,
+		false,
+		false,
 		n,
 		func(gs ygot.ValidatedGoStruct) (*oc.Model_OrderedList_OrderedMap, bool) {
 			ret := gs.(*oc.Model).OrderedList
@@ -1199,8 +1257,10 @@ func (n *Model_OrderedListPathAny) State() ygnmi.WildcardQuery[*oc.Model_Ordered
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Model_OrderedListPath) Config() ygnmi.ConfigQuery[*oc.Model_OrderedList_OrderedMap] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Model_OrderedList_OrderedMap](
+	return ygnmi.NewConfigQuery[*oc.Model_OrderedList_OrderedMap](
 		"Model",
+		false,
+		false,
 		false,
 		n,
 		func(gs ygot.ValidatedGoStruct) (*oc.Model_OrderedList_OrderedMap, bool) {
@@ -1208,7 +1268,6 @@ func (n *Model_OrderedListPath) Config() ygnmi.ConfigQuery[*oc.Model_OrderedList
 			return ret, ret != nil
 		},
 		func() ygot.ValidatedGoStruct { return new(oc.Model) },
-		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1216,6 +1275,7 @@ func (n *Model_OrderedListPath) Config() ygnmi.ConfigQuery[*oc.Model_OrderedList
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 		&ygnmi.CompressionInfo{
 			PreRelPath:  []string{"openconfig-withlistval:ordered-lists"},
 			PostRelPath: []string{"openconfig-withlistval:ordered-list"},
@@ -1225,8 +1285,10 @@ func (n *Model_OrderedListPath) Config() ygnmi.ConfigQuery[*oc.Model_OrderedList
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Model_OrderedListPathAny) Config() ygnmi.WildcardQuery[*oc.Model_OrderedList_OrderedMap] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_OrderedList_OrderedMap](
+	return ygnmi.NewWildcardQuery[*oc.Model_OrderedList_OrderedMap](
 		"Model",
+		false,
+		false,
 		false,
 		n,
 		func(gs ygot.ValidatedGoStruct) (*oc.Model_OrderedList_OrderedMap, bool) {
@@ -1267,8 +1329,9 @@ type Model_SingleKey_KeyPathAny struct {
 //	Path from parent:     "state/key"
 //	Path from root:       "/model/a/single-key/state/key"
 func (n *Model_SingleKey_KeyPath) State() ygnmi.SingletonQuery[string] {
-	return ygnmi.NewLeafSingletonQuery[string](
+	return ygnmi.NewSingletonQuery[string](
 		"Model_SingleKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1292,6 +1355,8 @@ func (n *Model_SingleKey_KeyPath) State() ygnmi.SingletonQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -1302,8 +1367,9 @@ func (n *Model_SingleKey_KeyPath) State() ygnmi.SingletonQuery[string] {
 //	Path from parent:     "state/key"
 //	Path from root:       "/model/a/single-key/state/key"
 func (n *Model_SingleKey_KeyPathAny) State() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"Model_SingleKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1327,6 +1393,7 @@ func (n *Model_SingleKey_KeyPathAny) State() ygnmi.WildcardQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1337,9 +1404,10 @@ func (n *Model_SingleKey_KeyPathAny) State() ygnmi.WildcardQuery[string] {
 //	Path from parent:     "config/key"
 //	Path from root:       "/model/a/single-key/config/key"
 func (n *Model_SingleKey_KeyPath) Config() ygnmi.ConfigQuery[string] {
-	return ygnmi.NewLeafConfigQuery[string](
+	return ygnmi.NewConfigQuery[string](
 		"Model_SingleKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "key"},
@@ -1362,6 +1430,8 @@ func (n *Model_SingleKey_KeyPath) Config() ygnmi.ConfigQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -1372,9 +1442,10 @@ func (n *Model_SingleKey_KeyPath) Config() ygnmi.ConfigQuery[string] {
 //	Path from parent:     "config/key"
 //	Path from root:       "/model/a/single-key/config/key"
 func (n *Model_SingleKey_KeyPathAny) Config() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"Model_SingleKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "key"},
@@ -1397,6 +1468,7 @@ func (n *Model_SingleKey_KeyPathAny) Config() ygnmi.WildcardQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1419,8 +1491,9 @@ type Model_SingleKey_ValuePathAny struct {
 //	Path from parent:     "state/value"
 //	Path from root:       "/model/a/single-key/state/value"
 func (n *Model_SingleKey_ValuePath) State() ygnmi.SingletonQuery[int64] {
-	return ygnmi.NewLeafSingletonQuery[int64](
+	return ygnmi.NewSingletonQuery[int64](
 		"Model_SingleKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1444,6 +1517,8 @@ func (n *Model_SingleKey_ValuePath) State() ygnmi.SingletonQuery[int64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -1454,8 +1529,9 @@ func (n *Model_SingleKey_ValuePath) State() ygnmi.SingletonQuery[int64] {
 //	Path from parent:     "state/value"
 //	Path from root:       "/model/a/single-key/state/value"
 func (n *Model_SingleKey_ValuePathAny) State() ygnmi.WildcardQuery[int64] {
-	return ygnmi.NewLeafWildcardQuery[int64](
+	return ygnmi.NewWildcardQuery[int64](
 		"Model_SingleKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1479,6 +1555,7 @@ func (n *Model_SingleKey_ValuePathAny) State() ygnmi.WildcardQuery[int64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1489,9 +1566,10 @@ func (n *Model_SingleKey_ValuePathAny) State() ygnmi.WildcardQuery[int64] {
 //	Path from parent:     "config/value"
 //	Path from root:       "/model/a/single-key/config/value"
 func (n *Model_SingleKey_ValuePath) Config() ygnmi.ConfigQuery[int64] {
-	return ygnmi.NewLeafConfigQuery[int64](
+	return ygnmi.NewConfigQuery[int64](
 		"Model_SingleKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "value"},
@@ -1514,6 +1592,8 @@ func (n *Model_SingleKey_ValuePath) Config() ygnmi.ConfigQuery[int64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -1524,9 +1604,10 @@ func (n *Model_SingleKey_ValuePath) Config() ygnmi.ConfigQuery[int64] {
 //	Path from parent:     "config/value"
 //	Path from root:       "/model/a/single-key/config/value"
 func (n *Model_SingleKey_ValuePathAny) Config() ygnmi.WildcardQuery[int64] {
-	return ygnmi.NewLeafWildcardQuery[int64](
+	return ygnmi.NewWildcardQuery[int64](
 		"Model_SingleKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "value"},
@@ -1549,6 +1630,7 @@ func (n *Model_SingleKey_ValuePathAny) Config() ygnmi.WildcardQuery[int64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1632,11 +1714,12 @@ func (n *Model_SingleKeyPathAny) Value() *Model_SingleKey_ValuePathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_SingleKeyPath) State() ygnmi.SingletonQuery[*oc.Model_SingleKey] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_SingleKey](
+	return ygnmi.NewSingletonQuery[*oc.Model_SingleKey](
 		"Model_SingleKey",
 		true,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1647,14 +1730,17 @@ func (n *Model_SingleKeyPath) State() ygnmi.SingletonQuery[*oc.Model_SingleKey] 
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_SingleKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_SingleKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_SingleKey](
+	return ygnmi.NewWildcardQuery[*oc.Model_SingleKey](
 		"Model_SingleKey",
 		true,
+		false,
+		false,
 		n,
 		nil,
 		nil,
@@ -1671,11 +1757,12 @@ func (n *Model_SingleKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_SingleKey
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Model_SingleKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_SingleKey] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Model_SingleKey](
+	return ygnmi.NewConfigQuery[*oc.Model_SingleKey](
 		"Model_SingleKey",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -1686,13 +1773,16 @@ func (n *Model_SingleKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_SingleKey] {
 			}
 		},
 		nil,
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Model_SingleKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_SingleKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_SingleKey](
+	return ygnmi.NewWildcardQuery[*oc.Model_SingleKey](
 		"Model_SingleKey",
+		false,
+		false,
 		false,
 		n,
 		nil,

--- a/exampleoc/withlistval/withlistval-0.go
+++ b/exampleoc/withlistval/withlistval-0.go
@@ -275,6 +275,8 @@ func (n *ModelPath) State() ygnmi.SingletonQuery[*oc.Model] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -282,6 +284,7 @@ func (n *ModelPath) State() ygnmi.SingletonQuery[*oc.Model] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -291,6 +294,8 @@ func (n *ModelPathAny) State() ygnmi.WildcardQuery[*oc.Model] {
 		"Model",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -298,6 +303,7 @@ func (n *ModelPathAny) State() ygnmi.WildcardQuery[*oc.Model] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -308,6 +314,8 @@ func (n *ModelPath) Config() ygnmi.ConfigQuery[*oc.Model] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -315,6 +323,7 @@ func (n *ModelPath) Config() ygnmi.ConfigQuery[*oc.Model] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -324,6 +333,8 @@ func (n *ModelPathAny) Config() ygnmi.WildcardQuery[*oc.Model] {
 		"Model",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -331,6 +342,7 @@ func (n *ModelPathAny) Config() ygnmi.WildcardQuery[*oc.Model] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -723,6 +735,8 @@ func (n *Model_MultiKeyPath) State() ygnmi.SingletonQuery[*oc.Model_MultiKey] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -730,6 +744,7 @@ func (n *Model_MultiKeyPath) State() ygnmi.SingletonQuery[*oc.Model_MultiKey] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -739,6 +754,8 @@ func (n *Model_MultiKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_MultiKey] 
 		"Model_MultiKey",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -746,6 +763,7 @@ func (n *Model_MultiKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_MultiKey] 
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -756,6 +774,8 @@ func (n *Model_MultiKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_MultiKey] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -763,6 +783,7 @@ func (n *Model_MultiKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_MultiKey] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -772,6 +793,8 @@ func (n *Model_MultiKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_MultiKey]
 		"Model_MultiKey",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -779,6 +802,7 @@ func (n *Model_MultiKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_MultiKey]
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -799,6 +823,8 @@ func (n *Model_NoKeyPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -806,6 +832,7 @@ func (n *Model_NoKeyPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -815,6 +842,8 @@ func (n *Model_NoKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_NoKey] {
 		"Model_NoKey",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -822,6 +851,7 @@ func (n *Model_NoKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_NoKey] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1074,6 +1104,8 @@ func (n *Model_NoKey_FooPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey_Foo] 
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1081,6 +1113,7 @@ func (n *Model_NoKey_FooPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey_Foo] 
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1090,6 +1123,8 @@ func (n *Model_NoKey_FooPathAny) State() ygnmi.WildcardQuery[*oc.Model_NoKey_Foo
 		"Model_NoKey_Foo",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1097,6 +1132,7 @@ func (n *Model_NoKey_FooPathAny) State() ygnmi.WildcardQuery[*oc.Model_NoKey_Foo
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1116,6 +1152,11 @@ func (n *Model_OrderedListPath) State() ygnmi.SingletonQuery[*oc.Model_OrderedLi
 		"Model",
 		true,
 		n,
+		func(gs ygot.ValidatedGoStruct) (*oc.Model_OrderedList_OrderedMap, bool) {
+			ret := gs.(*oc.Model).OrderedList
+			return ret, ret != nil
+		},
+		func() ygot.ValidatedGoStruct { return new(oc.Model) },
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1123,6 +1164,10 @@ func (n *Model_OrderedListPath) State() ygnmi.SingletonQuery[*oc.Model_OrderedLi
 				SchemaTree: oc.SchemaTree,
 				Unmarshal:  oc.Unmarshal,
 			}
+		},
+		&ygnmi.CompressionInfo{
+			PreRelPath:  []string{"openconfig-withlistval:ordered-lists"},
+			PostRelPath: []string{"openconfig-withlistval:ordered-list"},
 		},
 	)
 }
@@ -1133,12 +1178,21 @@ func (n *Model_OrderedListPathAny) State() ygnmi.WildcardQuery[*oc.Model_Ordered
 		"Model",
 		true,
 		n,
+		func(gs ygot.ValidatedGoStruct) (*oc.Model_OrderedList_OrderedMap, bool) {
+			ret := gs.(*oc.Model).OrderedList
+			return ret, ret != nil
+		},
+		func() ygot.ValidatedGoStruct { return new(oc.Model) },
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
 				SchemaTree: oc.SchemaTree,
 				Unmarshal:  oc.Unmarshal,
 			}
+		},
+		&ygnmi.CompressionInfo{
+			PreRelPath:  []string{"openconfig-withlistval:ordered-lists"},
+			PostRelPath: []string{"openconfig-withlistval:ordered-list"},
 		},
 	)
 }
@@ -1149,6 +1203,11 @@ func (n *Model_OrderedListPath) Config() ygnmi.ConfigQuery[*oc.Model_OrderedList
 		"Model",
 		false,
 		n,
+		func(gs ygot.ValidatedGoStruct) (*oc.Model_OrderedList_OrderedMap, bool) {
+			ret := gs.(*oc.Model).OrderedList
+			return ret, ret != nil
+		},
+		func() ygot.ValidatedGoStruct { return new(oc.Model) },
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1156,6 +1215,10 @@ func (n *Model_OrderedListPath) Config() ygnmi.ConfigQuery[*oc.Model_OrderedList
 				SchemaTree: oc.SchemaTree,
 				Unmarshal:  oc.Unmarshal,
 			}
+		},
+		&ygnmi.CompressionInfo{
+			PreRelPath:  []string{"openconfig-withlistval:ordered-lists"},
+			PostRelPath: []string{"openconfig-withlistval:ordered-list"},
 		},
 	)
 }
@@ -1166,12 +1229,21 @@ func (n *Model_OrderedListPathAny) Config() ygnmi.WildcardQuery[*oc.Model_Ordere
 		"Model",
 		false,
 		n,
+		func(gs ygot.ValidatedGoStruct) (*oc.Model_OrderedList_OrderedMap, bool) {
+			ret := gs.(*oc.Model).OrderedList
+			return ret, ret != nil
+		},
+		func() ygot.ValidatedGoStruct { return new(oc.Model) },
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
 				SchemaTree: oc.SchemaTree,
 				Unmarshal:  oc.Unmarshal,
 			}
+		},
+		&ygnmi.CompressionInfo{
+			PreRelPath:  []string{"openconfig-withlistval:ordered-lists"},
+			PostRelPath: []string{"openconfig-withlistval:ordered-list"},
 		},
 	)
 }
@@ -1565,6 +1637,8 @@ func (n *Model_SingleKeyPath) State() ygnmi.SingletonQuery[*oc.Model_SingleKey] 
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1572,6 +1646,7 @@ func (n *Model_SingleKeyPath) State() ygnmi.SingletonQuery[*oc.Model_SingleKey] 
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1581,6 +1656,8 @@ func (n *Model_SingleKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_SingleKey
 		"Model_SingleKey",
 		true,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1588,6 +1665,7 @@ func (n *Model_SingleKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_SingleKey
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1598,6 +1676,8 @@ func (n *Model_SingleKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_SingleKey] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1605,6 +1685,7 @@ func (n *Model_SingleKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_SingleKey] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1614,6 +1695,8 @@ func (n *Model_SingleKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_SingleKe
 		"Model_SingleKey",
 		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1621,5 +1704,6 @@ func (n *Model_SingleKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_SingleKe
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }

--- a/pathgen/gnmigen_test.go
+++ b/pathgen/gnmigen_test.go
@@ -385,14 +385,17 @@ func (b *Batch) State() ygnmi.SingletonQuery[*Root] {
         "Root",
         true,
         ygnmi.NewDeviceRootBase(),
+	nil,
+	nil,
         queryPaths,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
+	func() *ytypes.Schema {
+		return &ytypes.Schema{
+			Root:       &oc.Root{},
+			SchemaTree: oc.SchemaTree,
+			Unmarshal:  oc.Unmarshal,
+		}
+	},
+	nil,
     )
 }
 
@@ -405,14 +408,17 @@ func (b *Batch) Config() ygnmi.SingletonQuery[*oc.Root] {
         "Root",
         false,
         ygnmi.NewDeviceRootBase(),
+	nil,
+	nil,
         queryPaths,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
+	func() *ytypes.Schema {
+		return &ytypes.Schema{
+			Root:       &oc.Root{},
+			SchemaTree: oc.SchemaTree,
+			Unmarshal:  oc.Unmarshal,
+		}
+	},
+	nil,
     )
 }
 
@@ -423,6 +429,8 @@ func (n *Root) State() ygnmi.SingletonQuery[*Root] {
 		true,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -430,6 +438,7 @@ func (n *Root) State() ygnmi.SingletonQuery[*Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -440,6 +449,8 @@ func (n *Root) Config() ygnmi.ConfigQuery[*Root] {
 		false,
 		n,
 		nil,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -447,6 +458,7 @@ func (n *Root) Config() ygnmi.ConfigQuery[*Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 `,

--- a/pathgen/gnmigen_test.go
+++ b/pathgen/gnmigen_test.go
@@ -62,8 +62,9 @@ func TestGNMIGenerator(t *testing.T) {
 // 	Path from parent:     "leaf"
 // 	Path from root:       "/container/leaf"
 func (n *Container_Leaf) State() ygnmi.SingletonQuery[int32] {
-	return ygnmi.NewLeafSingletonQuery[int32](
+	return ygnmi.NewSingletonQuery[int32](
 		"Container",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -87,6 +88,8 @@ func (n *Container_Leaf) State() ygnmi.SingletonQuery[int32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -96,8 +99,9 @@ func (n *Container_Leaf) State() ygnmi.SingletonQuery[int32] {
 // 	Path from parent:     "leaf"
 // 	Path from root:       "/container/leaf"
 func (n *Container_LeafAny) State() ygnmi.WildcardQuery[int32] {
-	return ygnmi.NewLeafWildcardQuery[int32](
+	return ygnmi.NewWildcardQuery[int32](
 		"Container",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -121,6 +125,7 @@ func (n *Container_LeafAny) State() ygnmi.WildcardQuery[int32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 `,
@@ -157,8 +162,9 @@ func binarySliceToFloatSlice(in []oc.Binary) []float32 {
 // 	Path from parent:     "state/leaflist"
 // 	Path from root:       "/container-with-config/state/leaflist"
 func (n *Container_LeafList) State() ygnmi.SingletonQuery[[]uint32] {
-	return ygnmi.NewLeafSingletonQuery[[]uint32](
+	return ygnmi.NewSingletonQuery[[]uint32](
 		"Container",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -178,6 +184,8 @@ func (n *Container_LeafList) State() ygnmi.SingletonQuery[[]uint32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -187,8 +195,9 @@ func (n *Container_LeafList) State() ygnmi.SingletonQuery[[]uint32] {
 // 	Path from parent:     "state/leaflist"
 // 	Path from root:       "/container-with-config/state/leaflist"
 func (n *Container_LeafListAny) State() ygnmi.WildcardQuery[[]uint32] {
-	return ygnmi.NewLeafWildcardQuery[[]uint32](
+	return ygnmi.NewWildcardQuery[[]uint32](
 		"Container",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -208,6 +217,7 @@ func (n *Container_LeafListAny) State() ygnmi.WildcardQuery[[]uint32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -217,9 +227,10 @@ func (n *Container_LeafListAny) State() ygnmi.WildcardQuery[[]uint32] {
 // 	Path from parent:     "config/leaflist"
 // 	Path from root:       "/container-with-config/config/leaflist"
 func (n *Container_LeafList) Config() ygnmi.ConfigQuery[[]uint32] {
-	return ygnmi.NewLeafConfigQuery[[]uint32](
+	return ygnmi.NewConfigQuery[[]uint32](
 		"Container",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "leaflist"},
@@ -238,6 +249,8 @@ func (n *Container_LeafList) Config() ygnmi.ConfigQuery[[]uint32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -247,9 +260,10 @@ func (n *Container_LeafList) Config() ygnmi.ConfigQuery[[]uint32] {
 // 	Path from parent:     "config/leaflist"
 // 	Path from root:       "/container-with-config/config/leaflist"
 func (n *Container_LeafListAny) Config() ygnmi.WildcardQuery[[]uint32] {
-	return ygnmi.NewLeafWildcardQuery[[]uint32](
+	return ygnmi.NewWildcardQuery[[]uint32](
 		"Container",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "leaflist"},
@@ -268,6 +282,7 @@ func (n *Container_LeafListAny) Config() ygnmi.WildcardQuery[[]uint32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 `,
@@ -293,8 +308,9 @@ func (n *Container_LeafListAny) Config() ygnmi.WildcardQuery[[]uint32] {
 // 	Path from parent:     "leaf"
 // 	Path from root:       "/container/leaf"
 func (n *Container_Leaf) State() ygnmi.SingletonQuery[E_Child_Three] {
-	return ygnmi.NewLeafSingletonQuery[E_Child_Three](
+	return ygnmi.NewSingletonQuery[E_Child_Three](
 		"Container",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -314,6 +330,8 @@ func (n *Container_Leaf) State() ygnmi.SingletonQuery[E_Child_Three] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
+		nil,
 	)
 }
 
@@ -323,8 +341,9 @@ func (n *Container_Leaf) State() ygnmi.SingletonQuery[E_Child_Three] {
 // 	Path from parent:     "leaf"
 // 	Path from root:       "/container/leaf"
 func (n *Container_LeafAny) State() ygnmi.WildcardQuery[E_Child_Three] {
-	return ygnmi.NewLeafWildcardQuery[E_Child_Three](
+	return ygnmi.NewWildcardQuery[E_Child_Three](
 		"Container",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -344,6 +363,7 @@ func (n *Container_LeafAny) State() ygnmi.WildcardQuery[E_Child_Three] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 `,
@@ -381,22 +401,24 @@ func (b *Batch) AddPaths(paths ...ygnmi.PathStruct) *Batch {
 func (b *Batch) State() ygnmi.SingletonQuery[*Root] {
 	queryPaths := make([]ygnmi.PathStruct, len(b.paths))
 	copy(queryPaths, b.paths)
-    return ygnmi.NewNonLeafSingletonQuery[*Root](
-        "Root",
-        true,
-        ygnmi.NewDeviceRootBase(),
-	nil,
-	nil,
-        queryPaths,
-	func() *ytypes.Schema {
-		return &ytypes.Schema{
-			Root:       &oc.Root{},
-			SchemaTree: oc.SchemaTree,
-			Unmarshal:  oc.Unmarshal,
-		}
-	},
-	nil,
-    )
+	return ygnmi.NewSingletonQuery[*Root](
+		"Root",
+		true,
+		false,
+		false,
+		ygnmi.NewDeviceRootBase(),
+		nil,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+		queryPaths,
+		nil,
+	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
@@ -404,31 +426,12 @@ func (b *Batch) State() ygnmi.SingletonQuery[*Root] {
 func (b *Batch) Config() ygnmi.SingletonQuery[*oc.Root] {
 	queryPaths := make([]ygnmi.PathStruct, len(b.paths))
 	copy(queryPaths, b.paths)
-    return ygnmi.NewNonLeafSingletonQuery[*oc.Root](
-        "Root",
-        false,
-        ygnmi.NewDeviceRootBase(),
-	nil,
-	nil,
-        queryPaths,
-	func() *ytypes.Schema {
-		return &ytypes.Schema{
-			Root:       &oc.Root{},
-			SchemaTree: oc.SchemaTree,
-			Unmarshal:  oc.Unmarshal,
-		}
-	},
-	nil,
-    )
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *Root) State() ygnmi.SingletonQuery[*Root] {
-	return ygnmi.NewNonLeafSingletonQuery[*Root](
+	return ygnmi.NewSingletonQuery[*oc.Root](
 		"Root",
-		true,
-		n,
-		nil,
+		false,
+		false,
+		false,
+		ygnmi.NewDeviceRootBase(),
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -438,17 +441,41 @@ func (n *Root) State() ygnmi.SingletonQuery[*Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		queryPaths,
+		nil,
+	)
+}
+
+// State returns a Query that can be used in gNMI operations.
+func (n *Root) State() ygnmi.SingletonQuery[*Root] {
+	return ygnmi.NewSingletonQuery[*Root](
+		"Root",
+		true,
+		false,
+		false,
+		n,
+		nil,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+		nil,
 		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Root) Config() ygnmi.ConfigQuery[*Root] {
-	return ygnmi.NewNonLeafConfigQuery[*Root](
+	return ygnmi.NewConfigQuery[*Root](
 		"Root",
 		false,
+		false,
+		false,
 		n,
-		nil,
 		nil,
 		nil,
 		func() *ytypes.Schema {
@@ -458,6 +485,7 @@ func (n *Root) Config() ygnmi.ConfigQuery[*Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 		nil,
 	)
 }

--- a/pathgen/pathgen.go
+++ b/pathgen/pathgen.go
@@ -513,7 +513,7 @@ type NodeData struct {
 	DirectoryName string
 	// CompressInfo contains information about a compressed path element for a node
 	// which points to a path element that's compressed out.
-	CompressInfo CompressionInfo
+	CompressInfo *CompressionInfo
 }
 
 // CompressionInfo contains information about a compressed path element for a
@@ -524,12 +524,14 @@ type NodeData struct {
 // - PreRelPath: []{"openconfig-interfaces:interfaces"}
 // - PostRelPath: []{"openconfig-interfaces:interface"}
 type CompressionInfo struct {
-	// PreRelPath is the list of qualified path elements prior to the
-	// compressed-out node.
-	PreRelPath []string
-	// PostRelPath is the list of qualified path elements after the
-	// compressed-out node.
-	PostRelPath []string
+	// PreRelPath is the list of strings of qualified path elements prior
+	// to the compressed-out node in Go list syntax.
+	//
+	// e.g. "openconfig-withlistval:ordered-lists", "openconfig-withlistval:ordered-lists-again"
+	PreRelPathList string
+	// PreRelPath is the list of strings of qualified path elements after
+	// the compressed-out node in Go list syntax.
+	PostRelPathList string
 }
 
 // GetOrderedNodeDataNames returns the alphabetically-sorted slice of keys
@@ -800,9 +802,9 @@ func getNodeDataMap(ir *ygen.IR, fakeRootName, schemaStructPkgAccessor, pathStru
 					errs = util.AppendErr(errs, fmt.Errorf("expected two path elements for the relative path of an ordered map, got %d: %v", gotLen, relPath))
 					continue
 				}
-				nodeDataMap[pathStructName].CompressInfo = CompressionInfo{
-					PreRelPath:  []string{fmt.Sprintf("%s:%s", relMods[0], relPath[0])},
-					PostRelPath: []string{fmt.Sprintf("%s:%s", relMods[1], relPath[1])},
+				nodeDataMap[pathStructName].CompressInfo = &CompressionInfo{
+					PreRelPathList:  fmt.Sprintf(`"%s:%s"`, relMods[0], relPath[0]),
+					PostRelPathList: fmt.Sprintf(`"%s:%s"`, relMods[1], relPath[1]),
 				}
 			}
 		}

--- a/pathgen/pathgen_test.go
+++ b/pathgen/pathgen_test.go
@@ -533,9 +533,9 @@ func TestGeneratePathCode(t *testing.T) {
 				YANGPath:              "/openconfig-orderedlist/model/ordered-lists/ordered-list",
 				GoPathPackageName:     "ocstructs",
 				DirectoryName:         "/openconfig-orderedlist/model/ordered-lists/ordered-list",
-				CompressInfo: CompressionInfo{
-					PreRelPath:  []string{"openconfig-orderedlist:ordered-lists"},
-					PostRelPath: []string{"openconfig-orderedlist:ordered-list"},
+				CompressInfo: &CompressionInfo{
+					PreRelPathList:  `"openconfig-orderedlist:ordered-lists"`,
+					PostRelPathList: `"openconfig-orderedlist:ordered-list"`,
 				},
 			},
 			"Model_OrderedList_KeyPath": {

--- a/schemaless/schemaless.go
+++ b/schemaless/schemaless.go
@@ -39,15 +39,19 @@ func NewConfig[T any](path, origin string) (ygnmi.ConfigQuery[T], error) {
 		return nil, err
 	}
 
-	return ygnmi.NewLeafConfigQuery("",
+	return ygnmi.NewConfigQuery("",
 			false,
+			true,
 			scalar,
 			ps,
 			createFn,
 			func() ygot.ValidatedGoStruct {
 				return nil
 			},
-			func() *ytypes.Schema { return nil }),
+			func() *ytypes.Schema { return nil },
+			nil,
+			nil,
+		),
 		nil
 }
 
@@ -59,15 +63,18 @@ func NewWildcard[T any](path, origin string) (ygnmi.WildcardQuery[T], error) {
 		return nil, err
 	}
 
-	return ygnmi.NewLeafWildcardQuery("",
+	return ygnmi.NewWildcardQuery("",
 			false,
+			true,
 			scalar,
 			ps,
 			createFn,
 			func() ygot.ValidatedGoStruct {
 				return nil
 			},
-			func() *ytypes.Schema { return nil }),
+			func() *ytypes.Schema { return nil },
+			nil,
+		),
 		nil
 }
 

--- a/ygnmi/types.go
+++ b/ygnmi/types.go
@@ -22,12 +22,30 @@ import (
 	"github.com/openconfig/ygot/ytypes"
 )
 
-func newBaseQuery[T any](dir string, state bool, ps PathStruct, schemaFn func() *ytypes.Schema) baseQuery[T] {
+// CompressionInfo contains information about a compressed path element for a
+// node which points to a path element that's compressed out.
+//
+// e.g. for OpenConfig's /interfaces/interface, if a path points to
+// /interfaces, then CompressionInfo will be populated with the following:
+// - PreRelPath: []{"openconfig-interfaces:interfaces"}
+// - PostRelPath: []{"openconfig-interfaces:interface"}
+type CompressionInfo struct {
+	// PreRelPath is the list of qualified path elements prior to the
+	// compressed-out node.
+	PreRelPath []string
+	// PostRelPath is the list of qualified path elements after the
+	// compressed-out node.
+	PostRelPath []string
+}
+
+func newBaseQuery[T any](dir string, state bool, ps PathStruct, schemaFn func() *ytypes.Schema, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct) baseQuery[T] {
 	return baseQuery[T]{
 		goStructName: dir,
 		state:        state,
 		ps:           ps,
 		yschemaFn:    schemaFn,
+		extractFn:    extractFn,
+		goStructFn:   goStructFn,
 	}
 }
 
@@ -35,30 +53,33 @@ func newBaseQuery[T any](dir string, state bool, ps PathStruct, schemaFn func() 
 func NewLeafSingletonQuery[T any](parentDir string, state, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema) *LeafSingletonQuery[T] {
 	return &LeafSingletonQuery[T]{
 		leafBaseQuery: leafBaseQuery[T]{
-			baseQuery: newBaseQuery[T](
+			baseQuery: newBaseQuery(
 				parentDir,
 				state,
 				ps,
 				schemaFn,
+				extractFn,
+				goStructFn,
 			),
-			scalar:     scalar,
-			extractFn:  extractFn,
-			goStructFn: goStructFn,
+			scalar: scalar,
 		},
 	}
 }
 
 // NewNonLeafSingletonQuery creates a new NonLeafSingletonQuery object.
-func NewNonLeafSingletonQuery[T any](dir string, state bool, ps PathStruct, subPaths []PathStruct, schemaFn func() *ytypes.Schema) *NonLeafSingletonQuery[T] {
+func NewNonLeafSingletonQuery[T any](dir string, state bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, subPaths []PathStruct, schemaFn func() *ytypes.Schema, compressInfo *CompressionInfo) *NonLeafSingletonQuery[T] {
 	return &NonLeafSingletonQuery[T]{
 		nonLeafBaseQuery: nonLeafBaseQuery[T]{
-			baseQuery: newBaseQuery[T](
+			baseQuery: newBaseQuery(
 				dir,
 				state,
 				ps,
 				schemaFn,
+				extractFn,
+				goStructFn,
 			),
 			queryPathStructs: subPaths,
+			compInfo:         compressInfo,
 		},
 	}
 }
@@ -67,29 +88,32 @@ func NewNonLeafSingletonQuery[T any](dir string, state bool, ps PathStruct, subP
 func NewLeafConfigQuery[T any](parentDir string, state, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema) *LeafConfigQuery[T] {
 	return &LeafConfigQuery[T]{
 		leafBaseQuery: leafBaseQuery[T]{
-			baseQuery: newBaseQuery[T](
+			baseQuery: newBaseQuery(
 				parentDir,
 				state,
 				ps,
 				schemaFn,
+				extractFn,
+				goStructFn,
 			),
-			scalar:     scalar,
-			extractFn:  extractFn,
-			goStructFn: goStructFn,
+			scalar: scalar,
 		},
 	}
 }
 
 // NewNonLeafConfigQuery creates a new NewNonLeafConfigQuery object.
-func NewNonLeafConfigQuery[T any](dir string, state bool, ps PathStruct, subPaths []PathStruct, schemaFn func() *ytypes.Schema) *NonLeafConfigQuery[T] {
+func NewNonLeafConfigQuery[T any](dir string, state bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, subPaths []PathStruct, schemaFn func() *ytypes.Schema, compressInfo *CompressionInfo) *NonLeafConfigQuery[T] {
 	return &NonLeafConfigQuery[T]{
 		nonLeafBaseQuery: nonLeafBaseQuery[T]{
-			baseQuery: newBaseQuery[T](
+			baseQuery: newBaseQuery(
 				dir,
 				state,
 				ps,
 				schemaFn,
+				extractFn,
+				goStructFn,
 			),
+			compInfo: compressInfo,
 		},
 	}
 }
@@ -98,29 +122,32 @@ func NewNonLeafConfigQuery[T any](dir string, state bool, ps PathStruct, subPath
 func NewLeafWildcardQuery[T any](parentDir string, state, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema) *LeafWildcardQuery[T] {
 	return &LeafWildcardQuery[T]{
 		leafBaseQuery: leafBaseQuery[T]{
-			baseQuery: newBaseQuery[T](
+			baseQuery: newBaseQuery(
 				parentDir,
 				state,
 				ps,
 				schemaFn,
+				extractFn,
+				goStructFn,
 			),
-			scalar:     scalar,
-			extractFn:  extractFn,
-			goStructFn: goStructFn,
+			scalar: scalar,
 		},
 	}
 }
 
 // NewNonLeafWildcardQuery creates a new NewNonLeafWildcardQuery object.
-func NewNonLeafWildcardQuery[T any](dir string, state bool, ps PathStruct, schemaFn func() *ytypes.Schema) *NonLeafWildcardQuery[T] {
+func NewNonLeafWildcardQuery[T any](dir string, state bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema, compressInfo *CompressionInfo) *NonLeafWildcardQuery[T] {
 	return &NonLeafWildcardQuery[T]{
 		nonLeafBaseQuery: nonLeafBaseQuery[T]{
-			baseQuery: newBaseQuery[T](
+			baseQuery: newBaseQuery(
 				dir,
 				state,
 				ps,
 				schemaFn,
+				extractFn,
+				goStructFn,
 			),
+			compInfo: compressInfo,
 		},
 	}
 }
@@ -146,6 +173,7 @@ type LeafWildcardQuery[T any] struct {
 // IsWildcard prevents this struct from being used where a non wildcard path is expected.
 func (lq *LeafWildcardQuery[T]) IsWildcard() {}
 
+// baseQuery contains common fields for query objects.
 type baseQuery[T any] struct {
 	// goStructName is the name of the YANG directory or GoStruct which
 	// contains this node.
@@ -159,6 +187,17 @@ type baseQuery[T any] struct {
 	ps PathStruct
 	// yschemaFn is parsed YANG schema to use when unmarshalling data.
 	yschemaFn func() *ytypes.Schema
+	// extractFn extracts the value from the containing GoStruct.
+	//
+	// If this value is nil, then it is assumed that the baseQuery refers
+	// to a GoStruct and the value itself can be returned.
+	extractFn ExtractFn[T]
+	// goStructFn initializes a new GoStruct able to contain the given
+	// node.
+	//
+	// If this value is nil, then it is assumed that the baseQuery refers
+	// to a GoStruct and the type itself can be returned.
+	goStructFn func() ygot.ValidatedGoStruct
 }
 
 // dirName returns the YANG schema name of the GoStruct containing this node.
@@ -181,12 +220,29 @@ func (q *baseQuery[T]) schema() *ytypes.Schema {
 	return q.yschemaFn()
 }
 
+// goStruct returns new initialized GoStruct, gNMI notifications can be
+// unmarshalled into this struct.
+func (q *baseQuery[T]) goStruct() ygot.ValidatedGoStruct {
+	if q.goStructFn != nil {
+		return q.goStructFn()
+	}
+	var t T
+	gs := reflect.New(reflect.TypeOf(t).Elem())
+	return gs.Interface().(ygot.ValidatedGoStruct)
+}
+
+// extract extracts the value from the containing GoStruct, returning whether
+// the value exists.
+func (q *baseQuery[T]) extract(gs ygot.ValidatedGoStruct) (T, bool) {
+	if q.extractFn != nil {
+		return q.extractFn(gs)
+	}
+	val := gs.(T)
+	return val, !reflect.ValueOf(val).Elem().IsZero()
+}
+
 type leafBaseQuery[T any] struct {
 	baseQuery[T]
-	// extractFn is used to extract the value from the containing GoStruct.
-	extractFn ExtractFn[T]
-	// goStructFn initializes a new GoStruct containing this node.
-	goStructFn func() ygot.ValidatedGoStruct
 	// scalar is whether the type (T) for this path is a pointer field (*T) in the parent GoStruct.
 	scalar bool
 }
@@ -204,16 +260,6 @@ func (lq *leafBaseQuery[T]) String() string {
 	return path
 }
 
-// extract takes the parent GoStruct and returns the correct child field from it.
-func (lq *leafBaseQuery[T]) extract(gs ygot.ValidatedGoStruct) (T, bool) {
-	return lq.extractFn(gs)
-}
-
-// goStruct returns the parent struct of the leaf node.
-func (lq *leafBaseQuery[T]) goStruct() ygot.ValidatedGoStruct {
-	return lq.goStructFn()
-}
-
 // isLeaf returns true, as this Query type is only for leaves.
 func (lq *leafBaseQuery[T]) isLeaf() bool {
 	return true
@@ -228,6 +274,11 @@ func (lq *leafBaseQuery[T]) subPaths() []PathStruct {
 // isScalar returns whether the type (T) for this path is a pointer field (*T) in the parent GoStruct.
 func (lq *leafBaseQuery[T]) isScalar() bool {
 	return lq.scalar
+}
+
+// schema returns the schema used for unmarshalling.
+func (lq *leafBaseQuery[T]) compressInfo() *CompressionInfo {
+	return nil
 }
 
 // NonLeafSingletonQuery is implementation of SingletonQuery interface for non-leaf nodes.
@@ -253,6 +304,9 @@ type nonLeafBaseQuery[T any] struct {
 	// queryPathStructs are the paths used to for the gNMI subscription.
 	// They must be equal to or descendants of ps.
 	queryPathStructs []PathStruct
+	// compInfo stores compression information when the node points to a
+	// path that's compressed out in the generated code.
+	compInfo *CompressionInfo
 }
 
 // String returns gNMI path as string for the query.
@@ -266,22 +320,6 @@ func (lq *nonLeafBaseQuery[T]) String() string {
 		path = protoPath.String()
 	}
 	return path
-}
-
-// extract casts the input GoStruct to the concrete type for the query.
-// As non-leaves structs are always GoStructs, a simple cast is sufficient.
-func (lq *nonLeafBaseQuery[T]) extract(gs ygot.ValidatedGoStruct) (T, bool) {
-	val := gs.(T)
-	return val, !reflect.ValueOf(val).Elem().IsZero()
-}
-
-// goStruct returns new initialized GoStruct, gNMI notifications can be unmarshalled into this struct.
-func (lq *nonLeafBaseQuery[T]) goStruct() ygot.ValidatedGoStruct {
-	// Get the underlying type of T (which is a pointer), deference it to get the base type.
-	// Create a new instance of the base type and return it as a ValidatedGoStruct.
-	var t T
-	gs := reflect.New(reflect.TypeOf(t).Elem())
-	return gs.Interface().(ygot.ValidatedGoStruct)
 }
 
 // isLeaf returns false, as this Query type is only for non-leaves.
@@ -300,6 +338,11 @@ func (lq *nonLeafBaseQuery[T]) subPaths() []PathStruct {
 		return []PathStruct{lq.ps}
 	}
 	return lq.queryPathStructs
+}
+
+// schema returns the schema used for unmarshalling.
+func (lq *nonLeafBaseQuery[T]) compressInfo() *CompressionInfo {
+	return lq.compInfo
 }
 
 // LeafConfigQuery is implementation of ConfigQuery interface for leaf nodes.

--- a/ygnmi/types.go
+++ b/ygnmi/types.go
@@ -38,140 +38,92 @@ type CompressionInfo struct {
 	PostRelPath []string
 }
 
-func newBaseQuery[T any](dir string, state bool, ps PathStruct, schemaFn func() *ytypes.Schema, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct) baseQuery[T] {
-	return baseQuery[T]{
-		goStructName: dir,
-		state:        state,
-		ps:           ps,
-		yschemaFn:    schemaFn,
-		extractFn:    extractFn,
-		goStructFn:   goStructFn,
-	}
-}
-
-// NewLeafSingletonQuery creates a new LeafSingletonQuery object.
-func NewLeafSingletonQuery[T any](parentDir string, state, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema) *LeafSingletonQuery[T] {
-	return &LeafSingletonQuery[T]{
-		leafBaseQuery: leafBaseQuery[T]{
-			baseQuery: newBaseQuery(
-				parentDir,
-				state,
-				ps,
-				schemaFn,
-				extractFn,
-				goStructFn,
-			),
-			scalar: scalar,
-		},
-	}
-}
-
-// NewNonLeafSingletonQuery creates a new NonLeafSingletonQuery object.
-func NewNonLeafSingletonQuery[T any](dir string, state bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, subPaths []PathStruct, schemaFn func() *ytypes.Schema, compressInfo *CompressionInfo) *NonLeafSingletonQuery[T] {
-	return &NonLeafSingletonQuery[T]{
-		nonLeafBaseQuery: nonLeafBaseQuery[T]{
-			baseQuery: newBaseQuery(
-				dir,
-				state,
-				ps,
-				schemaFn,
-				extractFn,
-				goStructFn,
-			),
-			queryPathStructs: subPaths,
-			compInfo:         compressInfo,
-		},
-	}
-}
-
-// NewLeafConfigQuery creates a new NewLeafConfigQuery object.
-func NewLeafConfigQuery[T any](parentDir string, state, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema) *LeafConfigQuery[T] {
-	return &LeafConfigQuery[T]{
-		leafBaseQuery: leafBaseQuery[T]{
-			baseQuery: newBaseQuery(
-				parentDir,
-				state,
-				ps,
-				schemaFn,
-				extractFn,
-				goStructFn,
-			),
-			scalar: scalar,
-		},
-	}
-}
-
-// NewNonLeafConfigQuery creates a new NewNonLeafConfigQuery object.
-func NewNonLeafConfigQuery[T any](dir string, state bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, subPaths []PathStruct, schemaFn func() *ytypes.Schema, compressInfo *CompressionInfo) *NonLeafConfigQuery[T] {
-	return &NonLeafConfigQuery[T]{
-		nonLeafBaseQuery: nonLeafBaseQuery[T]{
-			baseQuery: newBaseQuery(
-				dir,
-				state,
-				ps,
-				schemaFn,
-				extractFn,
-				goStructFn,
-			),
-			compInfo: compressInfo,
-		},
-	}
-}
-
-// NewLeafWildcardQuery creates a new NewLeafWildcardQuery object.
-func NewLeafWildcardQuery[T any](parentDir string, state, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema) *LeafWildcardQuery[T] {
-	return &LeafWildcardQuery[T]{
-		leafBaseQuery: leafBaseQuery[T]{
-			baseQuery: newBaseQuery(
-				parentDir,
-				state,
-				ps,
-				schemaFn,
-				extractFn,
-				goStructFn,
-			),
-			scalar: scalar,
-		},
-	}
-}
-
-// NewNonLeafWildcardQuery creates a new NewNonLeafWildcardQuery object.
-func NewNonLeafWildcardQuery[T any](dir string, state bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema, compressInfo *CompressionInfo) *NonLeafWildcardQuery[T] {
-	return &NonLeafWildcardQuery[T]{
-		nonLeafBaseQuery: nonLeafBaseQuery[T]{
-			baseQuery: newBaseQuery(
-				dir,
-				state,
-				ps,
-				schemaFn,
-				extractFn,
-				goStructFn,
-			),
-			compInfo: compressInfo,
-		},
-	}
-}
-
 // ExtractFn is the type for the func that extracts a concrete val from a GoStruct.
 type ExtractFn[T any] func(ygot.ValidatedGoStruct) (T, bool)
 
-// LeafSingletonQuery is implementation of SingletonQuery interface for leaf nodes.
+// NewSingletonQuery creates a new SingletonQueryStruct object.
+func NewSingletonQuery[T any](goStructName string, state, leaf, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema, subPaths []PathStruct, compressInfo *CompressionInfo) *SingletonQueryStruct[T] {
+	return &SingletonQueryStruct[T]{
+		baseQuery: baseQuery[T]{
+			goStructName,
+			state,
+			ps,
+			leaf,
+			scalar,
+			schemaFn,
+			extractFn,
+			goStructFn,
+			subPaths,
+			compressInfo,
+		},
+	}
+}
+
+// NewConfigQuery creates a new NewLeafConfigQuery object.
+func NewConfigQuery[T any](goStructName string, state, leaf, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema, subPaths []PathStruct, compressInfo *CompressionInfo) *ConfigQueryStruct[T] {
+	return &ConfigQueryStruct[T]{
+		baseQuery: baseQuery[T]{
+			goStructName,
+			state,
+			ps,
+			leaf,
+			scalar,
+			schemaFn,
+			extractFn,
+			goStructFn,
+			nil,
+			compressInfo,
+		},
+	}
+}
+
+// NewWildcardQuery creates a new NewLeafWildcardQuery object.
+func NewWildcardQuery[T any](goStructName string, state, leaf, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema, compressInfo *CompressionInfo) *WildcardQueryStruct[T] {
+	return &WildcardQueryStruct[T]{
+		baseQuery: baseQuery[T]{
+			goStructName,
+			state,
+			ps,
+			leaf,
+			scalar,
+			schemaFn,
+			extractFn,
+			goStructFn,
+			nil,
+			compressInfo,
+		},
+	}
+}
+
+// SingletonQueryStruct is implementation of SingletonQuery interface.
 // Note: Do not use this type directly, instead use the generated Path API.
-type LeafSingletonQuery[T any] struct {
-	leafBaseQuery[T]
+type SingletonQueryStruct[T any] struct {
+	baseQuery[T]
 }
 
 // IsSingleton prevents this struct from being used where a wildcard path is expected.
-func (lq *LeafSingletonQuery[T]) IsSingleton() {}
+func (q *SingletonQueryStruct[T]) IsSingleton() {}
 
-// LeafWildcardQuery is implementation of SingletonQuery interface for leaf nodes.
+// WildcardQueryStruct is implementation of SingletonQuery interface for leaf nodes.
 // Note: Do not use this type directly, instead use the generated Path API.
-type LeafWildcardQuery[T any] struct {
-	leafBaseQuery[T]
+type WildcardQueryStruct[T any] struct {
+	baseQuery[T]
 }
 
 // IsWildcard prevents this struct from being used where a non wildcard path is expected.
-func (lq *LeafWildcardQuery[T]) IsWildcard() {}
+func (q *WildcardQueryStruct[T]) IsWildcard() {}
+
+// ConfigQueryStruct is implementation of ConfigQuery interface for leaf nodes.
+// Note: Do not use this type directly, instead use the generated Path API.
+type ConfigQueryStruct[T any] struct {
+	baseQuery[T]
+}
+
+// IsConfig restricts this struct to be used only where a config path is expected.
+func (q *ConfigQueryStruct[T]) IsConfig() {}
+
+// IsSingleton restricts this struct to be used only where a singleton path is expected.
+func (q *ConfigQueryStruct[T]) IsSingleton() {}
 
 // baseQuery contains common fields for query objects.
 type baseQuery[T any] struct {
@@ -185,6 +137,10 @@ type baseQuery[T any] struct {
 	state bool
 	// ps contains the path specification of the query.
 	ps PathStruct
+	// leaf indicates whether the query is on a leaf node.
+	leaf bool
+	// scalar is whether the type (T) for this path is a pointer field (*T) in the parent GoStruct.
+	scalar bool
 	// yschemaFn is parsed YANG schema to use when unmarshalling data.
 	yschemaFn func() *ytypes.Schema
 	// extractFn extracts the value from the containing GoStruct.
@@ -198,6 +154,12 @@ type baseQuery[T any] struct {
 	// If this value is nil, then it is assumed that the baseQuery refers
 	// to a GoStruct and the type itself can be returned.
 	goStructFn func() ygot.ValidatedGoStruct
+	// queryPathStructs are the paths used to for the gNMI subscription.
+	// They must be equal to or descendants of ps.
+	queryPathStructs []PathStruct
+	// compInfo stores compression information when the node points to a
+	// path that's compressed out in the generated code.
+	compInfo *CompressionInfo
 }
 
 // dirName returns the YANG schema name of the GoStruct containing this node.
@@ -220,151 +182,69 @@ func (q *baseQuery[T]) schema() *ytypes.Schema {
 	return q.yschemaFn()
 }
 
-// goStruct returns new initialized GoStruct, gNMI notifications can be
-// unmarshalled into this struct.
+// String returns gNMI path as string for the query.
+func (q *baseQuery[T]) String() string {
+	protoPath, _, err := ResolvePath(q.ps)
+	if err != nil {
+		return fmt.Sprintf("invalid path: %v", err)
+	}
+	path, err := ygot.PathToString(protoPath)
+	if err != nil {
+		path = protoPath.String()
+	}
+	return path
+}
+
+// extract extracts the unmarshalled value from the containing GoStruct.
+//
+// For queries on GoStructs it simply casts the input GoStruct to the concrete
+// type for the query.
+//
+// For other types it extracts and returns the correct child field from it.
+func (q *baseQuery[T]) extract(gs ygot.ValidatedGoStruct) (T, bool) {
+	if q.extractFn != nil {
+		return q.extractFn(gs)
+	}
+
+	val := gs.(T)
+	return val, !reflect.ValueOf(val).Elem().IsZero()
+}
+
+// goStruct returns new empty GoStruct into which gNMI notifications can be
+// unmarshalled.
 func (q *baseQuery[T]) goStruct() ygot.ValidatedGoStruct {
 	if q.goStructFn != nil {
 		return q.goStructFn()
 	}
+
+	// Get the underlying type of T (which is a pointer), deference it to get the base type.
+	// Create a new instance of the base type and return it as a ValidatedGoStruct.
 	var t T
 	gs := reflect.New(reflect.TypeOf(t).Elem())
 	return gs.Interface().(ygot.ValidatedGoStruct)
 }
 
-// extract extracts the value from the containing GoStruct, returning whether
-// the value exists.
-func (q *baseQuery[T]) extract(gs ygot.ValidatedGoStruct) (T, bool) {
-	if q.extractFn != nil {
-		return q.extractFn(gs)
-	}
-	val := gs.(T)
-	return val, !reflect.ValueOf(val).Elem().IsZero()
-}
-
-type leafBaseQuery[T any] struct {
-	baseQuery[T]
-	// scalar is whether the type (T) for this path is a pointer field (*T) in the parent GoStruct.
-	scalar bool
-}
-
-// String returns gNMI path as string for the query.
-func (lq *leafBaseQuery[T]) String() string {
-	protoPath, _, err := ResolvePath(lq.ps)
-	if err != nil {
-		return fmt.Sprintf("invalid path: %v", err)
-	}
-	path, err := ygot.PathToString(protoPath)
-	if err != nil {
-		path = protoPath.String()
-	}
-	return path
-}
-
-// isLeaf returns true, as this Query type is only for leaves.
-func (lq *leafBaseQuery[T]) isLeaf() bool {
-	return true
+// isLeaf returns whether the query refers to a leaf.
+func (q *baseQuery[T]) isLeaf() bool {
+	return q.leaf
 }
 
 // subPaths returns the path structs used for creating the gNMI subscription.
-// A leaf subscribes to the same path returned by PathStruct().
-func (lq *leafBaseQuery[T]) subPaths() []PathStruct {
-	return []PathStruct{lq.ps}
+func (q *baseQuery[T]) subPaths() []PathStruct {
+	if len(q.queryPathStructs) == 0 {
+		return []PathStruct{q.ps}
+	}
+	return q.queryPathStructs
 }
 
-// isScalar returns whether the type (T) for this path is a pointer field (*T) in the parent GoStruct.
-func (lq *leafBaseQuery[T]) isScalar() bool {
-	return lq.scalar
+// isScalar returns whether the type (T) for this path is a leaf type that is
+// represented by a pointer field (*T) in the parent GoStruct, but whose
+// natural type is not a pointer (e.g. YANG's string type).
+func (q *baseQuery[T]) isScalar() bool {
+	return q.scalar
 }
 
 // schema returns the schema used for unmarshalling.
-func (lq *leafBaseQuery[T]) compressInfo() *CompressionInfo {
-	return nil
+func (q *baseQuery[T]) compressInfo() *CompressionInfo {
+	return q.compInfo
 }
-
-// NonLeafSingletonQuery is implementation of SingletonQuery interface for non-leaf nodes.
-// Note: Do not use this type directly, instead use the generated Path API.
-type NonLeafSingletonQuery[T any] struct {
-	nonLeafBaseQuery[T]
-}
-
-// IsSingleton prevents this struct from being used where a wildcard path is expected.
-func (lq *NonLeafSingletonQuery[T]) IsSingleton() {}
-
-// NonLeafWildcardQuery is implementation of SingletonQuery interface for non-leaf nodes.
-// Note: Do not use this type directly, instead use the generated Path API.
-type NonLeafWildcardQuery[T any] struct {
-	nonLeafBaseQuery[T]
-}
-
-// IsWildcard prevents this struct from being used where a non-wildcard path is expected.
-func (lq *NonLeafWildcardQuery[T]) IsWildcard() {}
-
-type nonLeafBaseQuery[T any] struct {
-	baseQuery[T]
-	// queryPathStructs are the paths used to for the gNMI subscription.
-	// They must be equal to or descendants of ps.
-	queryPathStructs []PathStruct
-	// compInfo stores compression information when the node points to a
-	// path that's compressed out in the generated code.
-	compInfo *CompressionInfo
-}
-
-// String returns gNMI path as string for the query.
-func (lq *nonLeafBaseQuery[T]) String() string {
-	protoPath, _, err := ResolvePath(lq.ps)
-	if err != nil {
-		return fmt.Sprintf("invalid path: %v", err)
-	}
-	path, err := ygot.PathToString(protoPath)
-	if err != nil {
-		path = protoPath.String()
-	}
-	return path
-}
-
-// isLeaf returns false, as this Query type is only for non-leaves.
-func (lq *nonLeafBaseQuery[T]) isLeaf() bool {
-	return false
-}
-
-// isScalar returns false, as non-leafs are always non-scalar objects.
-func (lq *nonLeafBaseQuery[T]) isScalar() bool {
-	return false
-}
-
-// subPaths returns the path structs used for creating the gNMI subscription.
-func (lq *nonLeafBaseQuery[T]) subPaths() []PathStruct {
-	if len(lq.queryPathStructs) == 0 {
-		return []PathStruct{lq.ps}
-	}
-	return lq.queryPathStructs
-}
-
-// schema returns the schema used for unmarshalling.
-func (lq *nonLeafBaseQuery[T]) compressInfo() *CompressionInfo {
-	return lq.compInfo
-}
-
-// LeafConfigQuery is implementation of ConfigQuery interface for leaf nodes.
-// Note: Do not use this type directly, instead use the generated Path API.
-type LeafConfigQuery[T any] struct {
-	leafBaseQuery[T]
-}
-
-// IsConfig restricts this struct to be used only where a config path is expected.
-func (lq *LeafConfigQuery[T]) IsConfig() {}
-
-// IsSingleton restricts this struct to be used only where a singleton path is expected.
-func (lq *LeafConfigQuery[T]) IsSingleton() {}
-
-// NonLeafConfigQuery is implementation of ConfigQuery interface for non-leaf nodes.
-// Note: Do not use this type directly, instead use the generated Path API.
-type NonLeafConfigQuery[T any] struct {
-	nonLeafBaseQuery[T]
-}
-
-// IsConfig restricts this struct to be used only where a config path is expected.
-func (nlq *NonLeafConfigQuery[T]) IsConfig() {}
-
-// IsSingleton restricts this struct to be used only where a singleton path is expected.
-func (nlq *NonLeafConfigQuery[T]) IsSingleton() {}

--- a/ygnmi/unmarshal.go
+++ b/ygnmi/unmarshal.go
@@ -334,7 +334,6 @@ func unmarshal(data []*DataPoint, structSchema *yang.Entry, structPtr ygot.Valid
 		// obtain the sanitized path.
 
 		// TODO(wenbli): Support ordered maps.
-
 		relPath := util.TrimGNMIPathPrefix(dp.Path, util.PathStringToElements(structSchema.Path())[1:])
 		if dp.Value == nil {
 			var dopts []ytypes.DelNodeOpt

--- a/ygnmi/ygnmi.go
+++ b/ygnmi/ygnmi.go
@@ -684,14 +684,16 @@ func (b *Batch[T]) AddPaths(paths ...PathStruct) error {
 func (b *Batch[T]) Query() SingletonQuery[T] {
 	queryPaths := make([]PathStruct, len(b.paths))
 	copy(queryPaths, b.paths)
-	return NewNonLeafSingletonQuery[T](
+	return NewSingletonQuery[T](
 		b.root.dirName(),
 		b.root.IsState(),
+		false,
+		false,
 		b.root.PathStruct(),
 		nil,
 		nil,
-		queryPaths,
 		b.root.schema,
+		queryPaths,
 		b.root.compressInfo(),
 	)
 }

--- a/ygnmi/ygnmi.go
+++ b/ygnmi/ygnmi.go
@@ -57,6 +57,9 @@ type AnyQuery[T any] interface {
 	isScalar() bool
 	// schema returns the root schema used for unmarshalling.
 	schema() *ytypes.Schema
+	// compressInfo returns information about where the path points to an
+	// element that is compressed out (if applicable).
+	compressInfo() *CompressionInfo
 }
 
 // SingletonQuery is a non-wildcard gNMI query.
@@ -685,7 +688,10 @@ func (b *Batch[T]) Query() SingletonQuery[T] {
 		b.root.dirName(),
 		b.root.IsState(),
 		b.root.PathStruct(),
+		nil,
+		nil,
 		queryPaths,
 		b.root.schema,
+		b.root.compressInfo(),
 	)
 }


### PR DESCRIPTION
This is necessary because the query path for OrderedMaps ends at the container of the ordered list rather than the ordered list while the input type is the ordered map. This means that the marshalled/unmarshalled JSON doesn't match the path. Thus this information is required in order to wrap the incoming/outgoing JSON such that the value matches the path.

Specifically CompressionInfo comprises of a "pre" part and a "post" part. The "post" part is what's used to wrap the JSON when marshalling (e.g. doing a replace), and the "pre" part is used to wrap incoming JSON (e.g. Lookup) so that it can be unmarshalled to its parent GoStruct.