### PR TITLE
Unify leaf/non-leaf query structs into a single struct.

### DIFF
--- a/exampleoc/exampleocpath/exampleocpath.go
+++ b/exampleoc/exampleocpath/exampleocpath.go
@@ -130,11 +130,14 @@ func (b *Batch) AddPaths(paths ...ygnmi.PathStruct) *Batch {
 func (b *Batch) State() ygnmi.SingletonQuery[*oc.Root] {
 	queryPaths := make([]ygnmi.PathStruct, len(b.paths))
 	copy(queryPaths, b.paths)
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Root](
+	return ygnmi.NewSingletonQuery[*oc.Root](
 		"Root",
 		true,
+		false,
+		false,
 		ygnmi.NewDeviceRootBase(),
-		queryPaths,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -142,6 +145,7 @@ func (b *Batch) State() ygnmi.SingletonQuery[*oc.Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		queryPaths,
 	)
 }
 
@@ -150,11 +154,14 @@ func (b *Batch) State() ygnmi.SingletonQuery[*oc.Root] {
 func (b *Batch) Config() ygnmi.SingletonQuery[*oc.Root] {
 	queryPaths := make([]ygnmi.PathStruct, len(b.paths))
 	copy(queryPaths, b.paths)
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Root](
+	return ygnmi.NewSingletonQuery[*oc.Root](
 		"Root",
 		false,
+		false,
+		false,
 		ygnmi.NewDeviceRootBase(),
-		queryPaths,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -162,6 +169,7 @@ func (b *Batch) Config() ygnmi.SingletonQuery[*oc.Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		queryPaths,
 	)
 }
 
@@ -175,10 +183,13 @@ func binarySliceToFloatSlice(in []oc.Binary) []float32 {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *RootPath) State() ygnmi.SingletonQuery[*oc.Root] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Root](
+	return ygnmi.NewSingletonQuery[*oc.Root](
 		"Root",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -187,15 +198,19 @@ func (n *RootPath) State() ygnmi.SingletonQuery[*oc.Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *RootPath) Config() ygnmi.ConfigQuery[*oc.Root] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Root](
+	return ygnmi.NewConfigQuery[*oc.Root](
 		"Root",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -204,5 +219,6 @@ func (n *RootPath) Config() ygnmi.ConfigQuery[*oc.Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }

--- a/exampleoc/nested/nested-0.go
+++ b/exampleoc/nested/nested-0.go
@@ -86,10 +86,13 @@ func binarySliceToFloatSlice(in []oc.Binary) []float32 {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *APath) State() ygnmi.SingletonQuery[*oc.A] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A](
+	return ygnmi.NewSingletonQuery[*oc.A](
 		"A",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -98,15 +101,20 @@ func (n *APath) State() ygnmi.SingletonQuery[*oc.A] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *APathAny) State() ygnmi.WildcardQuery[*oc.A] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A](
+	return ygnmi.NewWildcardQuery[*oc.A](
 		"A",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -119,10 +127,13 @@ func (n *APathAny) State() ygnmi.WildcardQuery[*oc.A] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *APath) Config() ygnmi.ConfigQuery[*oc.A] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A](
+	return ygnmi.NewConfigQuery[*oc.A](
 		"A",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -131,15 +142,20 @@ func (n *APath) Config() ygnmi.ConfigQuery[*oc.A] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *APathAny) Config() ygnmi.WildcardQuery[*oc.A] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A](
+	return ygnmi.NewWildcardQuery[*oc.A](
 		"A",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -194,10 +210,13 @@ func (n *A_BPathAny) C() *A_B_CPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_BPath) State() ygnmi.SingletonQuery[*oc.A_B] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B](
+	return ygnmi.NewSingletonQuery[*oc.A_B](
 		"A_B",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -206,15 +225,20 @@ func (n *A_BPath) State() ygnmi.SingletonQuery[*oc.A_B] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_BPathAny) State() ygnmi.WildcardQuery[*oc.A_B] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B](
+	return ygnmi.NewWildcardQuery[*oc.A_B](
 		"A_B",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -227,10 +251,13 @@ func (n *A_BPathAny) State() ygnmi.WildcardQuery[*oc.A_B] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_BPath) Config() ygnmi.ConfigQuery[*oc.A_B] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B](
+	return ygnmi.NewConfigQuery[*oc.A_B](
 		"A_B",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -239,15 +266,20 @@ func (n *A_BPath) Config() ygnmi.ConfigQuery[*oc.A_B] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_BPathAny) Config() ygnmi.WildcardQuery[*oc.A_B] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B](
+	return ygnmi.NewWildcardQuery[*oc.A_B](
 		"A_B",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -302,10 +334,13 @@ func (n *A_B_CPathAny) D() *A_B_C_DPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_CPath) State() ygnmi.SingletonQuery[*oc.A_B_C] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C](
 		"A_B_C",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -314,15 +349,20 @@ func (n *A_B_CPath) State() ygnmi.SingletonQuery[*oc.A_B_C] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_CPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C](
 		"A_B_C",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -335,10 +375,13 @@ func (n *A_B_CPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_CPath) Config() ygnmi.ConfigQuery[*oc.A_B_C] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C](
+	return ygnmi.NewConfigQuery[*oc.A_B_C](
 		"A_B_C",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -347,15 +390,20 @@ func (n *A_B_CPath) Config() ygnmi.ConfigQuery[*oc.A_B_C] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_CPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C](
 		"A_B_C",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -410,10 +458,13 @@ func (n *A_B_C_DPathAny) E() *A_B_C_D_EPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_DPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D](
 		"A_B_C_D",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -422,15 +473,20 @@ func (n *A_B_C_DPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_DPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D](
 		"A_B_C_D",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -443,10 +499,13 @@ func (n *A_B_C_DPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_DPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D](
 		"A_B_C_D",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -455,15 +514,20 @@ func (n *A_B_C_DPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_DPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D](
 		"A_B_C_D",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -518,10 +582,13 @@ func (n *A_B_C_D_EPathAny) F() *A_B_C_D_E_FPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_EPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E](
 		"A_B_C_D_E",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -530,15 +597,20 @@ func (n *A_B_C_D_EPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_EPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E](
 		"A_B_C_D_E",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -551,10 +623,13 @@ func (n *A_B_C_D_EPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_EPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E](
 		"A_B_C_D_E",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -563,15 +638,20 @@ func (n *A_B_C_D_EPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_EPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E](
 		"A_B_C_D_E",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -626,10 +706,13 @@ func (n *A_B_C_D_E_FPathAny) G() *A_B_C_D_E_F_GPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_FPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F](
 		"A_B_C_D_E_F",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -638,15 +721,20 @@ func (n *A_B_C_D_E_FPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_FPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F](
 		"A_B_C_D_E_F",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -659,10 +747,13 @@ func (n *A_B_C_D_E_FPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_FPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F](
 		"A_B_C_D_E_F",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -671,15 +762,20 @@ func (n *A_B_C_D_E_FPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_FPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F](
 		"A_B_C_D_E_F",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -734,10 +830,13 @@ func (n *A_B_C_D_E_F_GPathAny) H() *A_B_C_D_E_F_G_HPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_GPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G](
 		"A_B_C_D_E_F_G",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -746,15 +845,20 @@ func (n *A_B_C_D_E_F_GPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_GPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G](
 		"A_B_C_D_E_F_G",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -767,10 +871,13 @@ func (n *A_B_C_D_E_F_GPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_GPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G](
 		"A_B_C_D_E_F_G",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -779,15 +886,20 @@ func (n *A_B_C_D_E_F_GPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_GPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G](
 		"A_B_C_D_E_F_G",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -842,10 +954,13 @@ func (n *A_B_C_D_E_F_G_HPathAny) I() *A_B_C_D_E_F_G_H_IPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_HPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G_H](
 		"A_B_C_D_E_F_G_H",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -854,15 +969,20 @@ func (n *A_B_C_D_E_F_G_HPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H] 
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_HPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H](
 		"A_B_C_D_E_F_G_H",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -875,10 +995,13 @@ func (n *A_B_C_D_E_F_G_HPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_HPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G_H](
 		"A_B_C_D_E_F_G_H",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -887,15 +1010,20 @@ func (n *A_B_C_D_E_F_G_HPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_HPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H](
 		"A_B_C_D_E_F_G_H",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -950,10 +1078,13 @@ func (n *A_B_C_D_E_F_G_H_IPathAny) J() *A_B_C_D_E_F_G_H_I_JPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_IPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H_I] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H_I](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G_H_I](
 		"A_B_C_D_E_F_G_H_I",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -962,15 +1093,20 @@ func (n *A_B_C_D_E_F_G_H_IPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_IPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I](
 		"A_B_C_D_E_F_G_H_I",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -983,10 +1119,13 @@ func (n *A_B_C_D_E_F_G_H_IPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_IPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H_I](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G_H_I](
 		"A_B_C_D_E_F_G_H_I",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -995,15 +1134,20 @@ func (n *A_B_C_D_E_F_G_H_IPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_IPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I](
 		"A_B_C_D_E_F_G_H_I",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1058,10 +1202,13 @@ func (n *A_B_C_D_E_F_G_H_I_JPathAny) K() *A_B_C_D_E_F_G_H_I_J_KPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_JPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J](
 		"A_B_C_D_E_F_G_H_I_J",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1070,15 +1217,20 @@ func (n *A_B_C_D_E_F_G_H_I_JPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_JPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J](
 		"A_B_C_D_E_F_G_H_I_J",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1091,10 +1243,13 @@ func (n *A_B_C_D_E_F_G_H_I_JPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_JPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J](
 		"A_B_C_D_E_F_G_H_I_J",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1103,15 +1258,20 @@ func (n *A_B_C_D_E_F_G_H_I_JPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_JPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J](
 		"A_B_C_D_E_F_G_H_I_J",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1166,10 +1326,13 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPathAny) L() *A_B_C_D_E_F_G_H_I_J_K_LPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_KPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
 		"A_B_C_D_E_F_G_H_I_J_K",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1178,15 +1341,20 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_KPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
 		"A_B_C_D_E_F_G_H_I_J_K",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1199,10 +1367,13 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_KPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
 		"A_B_C_D_E_F_G_H_I_J_K",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1211,15 +1382,20 @@ func (n *A_B_C_D_E_F_G_H_I_J_KPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_KPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K](
 		"A_B_C_D_E_F_G_H_I_J_K",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1274,10 +1450,13 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPathAny) M() *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_LPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
 		"A_B_C_D_E_F_G_H_I_J_K_L",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1286,15 +1465,20 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_LPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
 		"A_B_C_D_E_F_G_H_I_J_K_L",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1307,10 +1491,13 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_LPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
 		"A_B_C_D_E_F_G_H_I_J_K_L",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1319,15 +1506,20 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_LPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_LPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L](
 		"A_B_C_D_E_F_G_H_I_J_K_L",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1357,8 +1549,9 @@ type A_B_C_D_E_F_G_H_I_J_K_L_M_FooPathAny struct {
 //	Path from parent:     "state/foo"
 //	Path from root:       "/a/b/c/d/e/f/g/h/i/j/k/l/m/state/foo"
 func (n *A_B_C_D_E_F_G_H_I_J_K_L_M_FooPath) State() ygnmi.SingletonQuery[string] {
-	return ygnmi.NewLeafSingletonQuery[string](
+	return ygnmi.NewSingletonQuery[string](
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1382,6 +1575,7 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_M_FooPath) State() ygnmi.SingletonQuery[string]
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1392,8 +1586,9 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_M_FooPath) State() ygnmi.SingletonQuery[string]
 //	Path from parent:     "state/foo"
 //	Path from root:       "/a/b/c/d/e/f/g/h/i/j/k/l/m/state/foo"
 func (n *A_B_C_D_E_F_G_H_I_J_K_L_M_FooPathAny) State() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1466,10 +1661,13 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) Foo() *A_B_C_D_E_F_G_H_I_J_K_L_M_FooP
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
+	return ygnmi.NewSingletonQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1478,15 +1676,20 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) State() ygnmi.SingletonQuery[*oc.A_B_C_D
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1499,10 +1702,13 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) State() ygnmi.WildcardQuery[*oc.A_B_C
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
+	return ygnmi.NewConfigQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1511,15 +1717,20 @@ func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPath) Config() ygnmi.ConfigQuery[*oc.A_B_C_D_E
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *A_B_C_D_E_F_G_H_I_J_K_L_MPathAny) Config() ygnmi.WildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
+	return ygnmi.NewWildcardQuery[*oc.A_B_C_D_E_F_G_H_I_J_K_L_M](
 		"A_B_C_D_E_F_G_H_I_J_K_L_M",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},

--- a/exampleoc/simple/simple-0.go
+++ b/exampleoc/simple/simple-0.go
@@ -88,10 +88,13 @@ func binarySliceToFloatSlice(in []oc.Binary) []float32 {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *ParentPath) State() ygnmi.SingletonQuery[*oc.Parent] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Parent](
+	return ygnmi.NewSingletonQuery[*oc.Parent](
 		"Parent",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -100,15 +103,20 @@ func (n *ParentPath) State() ygnmi.SingletonQuery[*oc.Parent] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *ParentPathAny) State() ygnmi.WildcardQuery[*oc.Parent] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Parent](
+	return ygnmi.NewWildcardQuery[*oc.Parent](
 		"Parent",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -121,10 +129,13 @@ func (n *ParentPathAny) State() ygnmi.WildcardQuery[*oc.Parent] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *ParentPath) Config() ygnmi.ConfigQuery[*oc.Parent] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Parent](
+	return ygnmi.NewConfigQuery[*oc.Parent](
 		"Parent",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -133,15 +144,20 @@ func (n *ParentPath) Config() ygnmi.ConfigQuery[*oc.Parent] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *ParentPathAny) Config() ygnmi.WildcardQuery[*oc.Parent] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Parent](
+	return ygnmi.NewWildcardQuery[*oc.Parent](
 		"Parent",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -171,8 +187,9 @@ type Parent_Child_FivePathAny struct {
 //	Path from parent:     "state/five"
 //	Path from root:       "/parent/child/state/five"
 func (n *Parent_Child_FivePath) State() ygnmi.SingletonQuery[float32] {
-	return ygnmi.NewLeafSingletonQuery[float32](
+	return ygnmi.NewSingletonQuery[float32](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -192,6 +209,7 @@ func (n *Parent_Child_FivePath) State() ygnmi.SingletonQuery[float32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -202,8 +220,9 @@ func (n *Parent_Child_FivePath) State() ygnmi.SingletonQuery[float32] {
 //	Path from parent:     "state/five"
 //	Path from root:       "/parent/child/state/five"
 func (n *Parent_Child_FivePathAny) State() ygnmi.WildcardQuery[float32] {
-	return ygnmi.NewLeafWildcardQuery[float32](
+	return ygnmi.NewWildcardQuery[float32](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -233,9 +252,10 @@ func (n *Parent_Child_FivePathAny) State() ygnmi.WildcardQuery[float32] {
 //	Path from parent:     "config/five"
 //	Path from root:       "/parent/child/config/five"
 func (n *Parent_Child_FivePath) Config() ygnmi.ConfigQuery[float32] {
-	return ygnmi.NewLeafConfigQuery[float32](
+	return ygnmi.NewConfigQuery[float32](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "five"},
@@ -254,6 +274,7 @@ func (n *Parent_Child_FivePath) Config() ygnmi.ConfigQuery[float32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -264,9 +285,10 @@ func (n *Parent_Child_FivePath) Config() ygnmi.ConfigQuery[float32] {
 //	Path from parent:     "config/five"
 //	Path from root:       "/parent/child/config/five"
 func (n *Parent_Child_FivePathAny) Config() ygnmi.WildcardQuery[float32] {
-	return ygnmi.NewLeafWildcardQuery[float32](
+	return ygnmi.NewWildcardQuery[float32](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "five"},
@@ -307,8 +329,9 @@ type Parent_Child_FourPathAny struct {
 //	Path from parent:     "state/four"
 //	Path from root:       "/parent/child/state/four"
 func (n *Parent_Child_FourPath) State() ygnmi.SingletonQuery[oc.Binary] {
-	return ygnmi.NewLeafSingletonQuery[oc.Binary](
+	return ygnmi.NewSingletonQuery[oc.Binary](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -328,6 +351,7 @@ func (n *Parent_Child_FourPath) State() ygnmi.SingletonQuery[oc.Binary] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -338,8 +362,9 @@ func (n *Parent_Child_FourPath) State() ygnmi.SingletonQuery[oc.Binary] {
 //	Path from parent:     "state/four"
 //	Path from root:       "/parent/child/state/four"
 func (n *Parent_Child_FourPathAny) State() ygnmi.WildcardQuery[oc.Binary] {
-	return ygnmi.NewLeafWildcardQuery[oc.Binary](
+	return ygnmi.NewWildcardQuery[oc.Binary](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -369,9 +394,10 @@ func (n *Parent_Child_FourPathAny) State() ygnmi.WildcardQuery[oc.Binary] {
 //	Path from parent:     "config/four"
 //	Path from root:       "/parent/child/config/four"
 func (n *Parent_Child_FourPath) Config() ygnmi.ConfigQuery[oc.Binary] {
-	return ygnmi.NewLeafConfigQuery[oc.Binary](
+	return ygnmi.NewConfigQuery[oc.Binary](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "four"},
@@ -390,6 +416,7 @@ func (n *Parent_Child_FourPath) Config() ygnmi.ConfigQuery[oc.Binary] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -400,9 +427,10 @@ func (n *Parent_Child_FourPath) Config() ygnmi.ConfigQuery[oc.Binary] {
 //	Path from parent:     "config/four"
 //	Path from root:       "/parent/child/config/four"
 func (n *Parent_Child_FourPathAny) Config() ygnmi.WildcardQuery[oc.Binary] {
-	return ygnmi.NewLeafWildcardQuery[oc.Binary](
+	return ygnmi.NewWildcardQuery[oc.Binary](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "four"},
@@ -443,8 +471,9 @@ type Parent_Child_OnePathAny struct {
 //	Path from parent:     "state/one"
 //	Path from root:       "/parent/child/state/one"
 func (n *Parent_Child_OnePath) State() ygnmi.SingletonQuery[string] {
-	return ygnmi.NewLeafSingletonQuery[string](
+	return ygnmi.NewSingletonQuery[string](
 		"Parent_Child",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -468,6 +497,7 @@ func (n *Parent_Child_OnePath) State() ygnmi.SingletonQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -478,8 +508,9 @@ func (n *Parent_Child_OnePath) State() ygnmi.SingletonQuery[string] {
 //	Path from parent:     "state/one"
 //	Path from root:       "/parent/child/state/one"
 func (n *Parent_Child_OnePathAny) State() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"Parent_Child",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -513,9 +544,10 @@ func (n *Parent_Child_OnePathAny) State() ygnmi.WildcardQuery[string] {
 //	Path from parent:     "config/one"
 //	Path from root:       "/parent/child/config/one"
 func (n *Parent_Child_OnePath) Config() ygnmi.ConfigQuery[string] {
-	return ygnmi.NewLeafConfigQuery[string](
+	return ygnmi.NewConfigQuery[string](
 		"Parent_Child",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "one"},
@@ -538,6 +570,7 @@ func (n *Parent_Child_OnePath) Config() ygnmi.ConfigQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -548,9 +581,10 @@ func (n *Parent_Child_OnePath) Config() ygnmi.ConfigQuery[string] {
 //	Path from parent:     "config/one"
 //	Path from root:       "/parent/child/config/one"
 func (n *Parent_Child_OnePathAny) Config() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"Parent_Child",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "one"},
@@ -595,8 +629,9 @@ type Parent_Child_SixPathAny struct {
 //	Path from parent:     "state/six"
 //	Path from root:       "/parent/child/state/six"
 func (n *Parent_Child_SixPath) State() ygnmi.SingletonQuery[[]float32] {
-	return ygnmi.NewLeafSingletonQuery[[]float32](
+	return ygnmi.NewSingletonQuery[[]float32](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -616,6 +651,7 @@ func (n *Parent_Child_SixPath) State() ygnmi.SingletonQuery[[]float32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -626,8 +662,9 @@ func (n *Parent_Child_SixPath) State() ygnmi.SingletonQuery[[]float32] {
 //	Path from parent:     "state/six"
 //	Path from root:       "/parent/child/state/six"
 func (n *Parent_Child_SixPathAny) State() ygnmi.WildcardQuery[[]float32] {
-	return ygnmi.NewLeafWildcardQuery[[]float32](
+	return ygnmi.NewWildcardQuery[[]float32](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -657,9 +694,10 @@ func (n *Parent_Child_SixPathAny) State() ygnmi.WildcardQuery[[]float32] {
 //	Path from parent:     "config/six"
 //	Path from root:       "/parent/child/config/six"
 func (n *Parent_Child_SixPath) Config() ygnmi.ConfigQuery[[]float32] {
-	return ygnmi.NewLeafConfigQuery[[]float32](
+	return ygnmi.NewConfigQuery[[]float32](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "six"},
@@ -678,6 +716,7 @@ func (n *Parent_Child_SixPath) Config() ygnmi.ConfigQuery[[]float32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -688,9 +727,10 @@ func (n *Parent_Child_SixPath) Config() ygnmi.ConfigQuery[[]float32] {
 //	Path from parent:     "config/six"
 //	Path from root:       "/parent/child/config/six"
 func (n *Parent_Child_SixPathAny) Config() ygnmi.WildcardQuery[[]float32] {
-	return ygnmi.NewLeafWildcardQuery[[]float32](
+	return ygnmi.NewWildcardQuery[[]float32](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "six"},
@@ -731,8 +771,9 @@ type Parent_Child_ThreePathAny struct {
 //	Path from parent:     "state/three"
 //	Path from root:       "/parent/child/state/three"
 func (n *Parent_Child_ThreePath) State() ygnmi.SingletonQuery[oc.E_Child_Three] {
-	return ygnmi.NewLeafSingletonQuery[oc.E_Child_Three](
+	return ygnmi.NewSingletonQuery[oc.E_Child_Three](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -752,6 +793,7 @@ func (n *Parent_Child_ThreePath) State() ygnmi.SingletonQuery[oc.E_Child_Three] 
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -762,8 +804,9 @@ func (n *Parent_Child_ThreePath) State() ygnmi.SingletonQuery[oc.E_Child_Three] 
 //	Path from parent:     "state/three"
 //	Path from root:       "/parent/child/state/three"
 func (n *Parent_Child_ThreePathAny) State() ygnmi.WildcardQuery[oc.E_Child_Three] {
-	return ygnmi.NewLeafWildcardQuery[oc.E_Child_Three](
+	return ygnmi.NewWildcardQuery[oc.E_Child_Three](
 		"Parent_Child",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -793,9 +836,10 @@ func (n *Parent_Child_ThreePathAny) State() ygnmi.WildcardQuery[oc.E_Child_Three
 //	Path from parent:     "config/three"
 //	Path from root:       "/parent/child/config/three"
 func (n *Parent_Child_ThreePath) Config() ygnmi.ConfigQuery[oc.E_Child_Three] {
-	return ygnmi.NewLeafConfigQuery[oc.E_Child_Three](
+	return ygnmi.NewConfigQuery[oc.E_Child_Three](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "three"},
@@ -814,6 +858,7 @@ func (n *Parent_Child_ThreePath) Config() ygnmi.ConfigQuery[oc.E_Child_Three] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -824,9 +869,10 @@ func (n *Parent_Child_ThreePath) Config() ygnmi.ConfigQuery[oc.E_Child_Three] {
 //	Path from parent:     "config/three"
 //	Path from root:       "/parent/child/config/three"
 func (n *Parent_Child_ThreePathAny) Config() ygnmi.WildcardQuery[oc.E_Child_Three] {
-	return ygnmi.NewLeafWildcardQuery[oc.E_Child_Three](
+	return ygnmi.NewWildcardQuery[oc.E_Child_Three](
 		"Parent_Child",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "three"},
@@ -867,8 +913,9 @@ type Parent_Child_TwoPathAny struct {
 //	Path from parent:     "state/two"
 //	Path from root:       "/parent/child/state/two"
 func (n *Parent_Child_TwoPath) State() ygnmi.SingletonQuery[string] {
-	return ygnmi.NewLeafSingletonQuery[string](
+	return ygnmi.NewSingletonQuery[string](
 		"Parent_Child",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -892,6 +939,7 @@ func (n *Parent_Child_TwoPath) State() ygnmi.SingletonQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -902,8 +950,9 @@ func (n *Parent_Child_TwoPath) State() ygnmi.SingletonQuery[string] {
 //	Path from parent:     "state/two"
 //	Path from root:       "/parent/child/state/two"
 func (n *Parent_Child_TwoPathAny) State() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"Parent_Child",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1146,10 +1195,13 @@ func (n *Parent_ChildPathAny) Two() *Parent_Child_TwoPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Parent_ChildPath) State() ygnmi.SingletonQuery[*oc.Parent_Child] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Parent_Child](
+	return ygnmi.NewSingletonQuery[*oc.Parent_Child](
 		"Parent_Child",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1158,15 +1210,20 @@ func (n *Parent_ChildPath) State() ygnmi.SingletonQuery[*oc.Parent_Child] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Parent_ChildPathAny) State() ygnmi.WildcardQuery[*oc.Parent_Child] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Parent_Child](
+	return ygnmi.NewWildcardQuery[*oc.Parent_Child](
 		"Parent_Child",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1179,10 +1236,13 @@ func (n *Parent_ChildPathAny) State() ygnmi.WildcardQuery[*oc.Parent_Child] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Parent_ChildPath) Config() ygnmi.ConfigQuery[*oc.Parent_Child] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Parent_Child](
+	return ygnmi.NewConfigQuery[*oc.Parent_Child](
 		"Parent_Child",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1191,15 +1251,20 @@ func (n *Parent_ChildPath) Config() ygnmi.ConfigQuery[*oc.Parent_Child] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Parent_ChildPathAny) Config() ygnmi.WildcardQuery[*oc.Parent_Child] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Parent_Child](
+	return ygnmi.NewWildcardQuery[*oc.Parent_Child](
 		"Parent_Child",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1229,8 +1294,9 @@ type RemoteContainer_ALeafPathAny struct {
 //	Path from parent:     "state/a-leaf"
 //	Path from root:       "/remote-container/state/a-leaf"
 func (n *RemoteContainer_ALeafPath) State() ygnmi.SingletonQuery[string] {
-	return ygnmi.NewLeafSingletonQuery[string](
+	return ygnmi.NewSingletonQuery[string](
 		"RemoteContainer",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1254,6 +1320,7 @@ func (n *RemoteContainer_ALeafPath) State() ygnmi.SingletonQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1264,8 +1331,9 @@ func (n *RemoteContainer_ALeafPath) State() ygnmi.SingletonQuery[string] {
 //	Path from parent:     "state/a-leaf"
 //	Path from root:       "/remote-container/state/a-leaf"
 func (n *RemoteContainer_ALeafPathAny) State() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"RemoteContainer",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1299,9 +1367,10 @@ func (n *RemoteContainer_ALeafPathAny) State() ygnmi.WildcardQuery[string] {
 //	Path from parent:     "config/a-leaf"
 //	Path from root:       "/remote-container/config/a-leaf"
 func (n *RemoteContainer_ALeafPath) Config() ygnmi.ConfigQuery[string] {
-	return ygnmi.NewLeafConfigQuery[string](
+	return ygnmi.NewConfigQuery[string](
 		"RemoteContainer",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "a-leaf"},
@@ -1324,6 +1393,7 @@ func (n *RemoteContainer_ALeafPath) Config() ygnmi.ConfigQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1334,9 +1404,10 @@ func (n *RemoteContainer_ALeafPath) Config() ygnmi.ConfigQuery[string] {
 //	Path from parent:     "config/a-leaf"
 //	Path from root:       "/remote-container/config/a-leaf"
 func (n *RemoteContainer_ALeafPathAny) Config() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"RemoteContainer",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "a-leaf"},
@@ -1408,10 +1479,13 @@ func (n *RemoteContainerPathAny) ALeaf() *RemoteContainer_ALeafPathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *RemoteContainerPath) State() ygnmi.SingletonQuery[*oc.RemoteContainer] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.RemoteContainer](
+	return ygnmi.NewSingletonQuery[*oc.RemoteContainer](
 		"RemoteContainer",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1420,15 +1494,20 @@ func (n *RemoteContainerPath) State() ygnmi.SingletonQuery[*oc.RemoteContainer] 
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *RemoteContainerPathAny) State() ygnmi.WildcardQuery[*oc.RemoteContainer] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.RemoteContainer](
+	return ygnmi.NewWildcardQuery[*oc.RemoteContainer](
 		"RemoteContainer",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1441,10 +1520,13 @@ func (n *RemoteContainerPathAny) State() ygnmi.WildcardQuery[*oc.RemoteContainer
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *RemoteContainerPath) Config() ygnmi.ConfigQuery[*oc.RemoteContainer] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.RemoteContainer](
+	return ygnmi.NewConfigQuery[*oc.RemoteContainer](
 		"RemoteContainer",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1453,15 +1535,20 @@ func (n *RemoteContainerPath) Config() ygnmi.ConfigQuery[*oc.RemoteContainer] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *RemoteContainerPathAny) Config() ygnmi.WildcardQuery[*oc.RemoteContainer] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.RemoteContainer](
+	return ygnmi.NewWildcardQuery[*oc.RemoteContainer](
 		"RemoteContainer",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},

--- a/exampleoc/withlistval/withlistval-0.go
+++ b/exampleoc/withlistval/withlistval-0.go
@@ -238,10 +238,13 @@ func binarySliceToFloatSlice(in []oc.Binary) []float32 {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *ModelPath) State() ygnmi.SingletonQuery[*oc.Model] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model](
+	return ygnmi.NewSingletonQuery[*oc.Model](
 		"Model",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -250,15 +253,20 @@ func (n *ModelPath) State() ygnmi.SingletonQuery[*oc.Model] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *ModelPathAny) State() ygnmi.WildcardQuery[*oc.Model] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model](
+	return ygnmi.NewWildcardQuery[*oc.Model](
 		"Model",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -271,10 +279,13 @@ func (n *ModelPathAny) State() ygnmi.WildcardQuery[*oc.Model] {
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *ModelPath) Config() ygnmi.ConfigQuery[*oc.Model] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Model](
+	return ygnmi.NewConfigQuery[*oc.Model](
 		"Model",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -283,15 +294,20 @@ func (n *ModelPath) Config() ygnmi.ConfigQuery[*oc.Model] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *ModelPathAny) Config() ygnmi.WildcardQuery[*oc.Model] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model](
+	return ygnmi.NewWildcardQuery[*oc.Model](
 		"Model",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -321,8 +337,9 @@ type Model_MultiKey_Key1PathAny struct {
 //	Path from parent:     "state/key1"
 //	Path from root:       "/model/b/multi-key/state/key1"
 func (n *Model_MultiKey_Key1Path) State() ygnmi.SingletonQuery[uint32] {
-	return ygnmi.NewLeafSingletonQuery[uint32](
+	return ygnmi.NewSingletonQuery[uint32](
 		"Model_MultiKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -346,6 +363,7 @@ func (n *Model_MultiKey_Key1Path) State() ygnmi.SingletonQuery[uint32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -356,8 +374,9 @@ func (n *Model_MultiKey_Key1Path) State() ygnmi.SingletonQuery[uint32] {
 //	Path from parent:     "state/key1"
 //	Path from root:       "/model/b/multi-key/state/key1"
 func (n *Model_MultiKey_Key1PathAny) State() ygnmi.WildcardQuery[uint32] {
-	return ygnmi.NewLeafWildcardQuery[uint32](
+	return ygnmi.NewWildcardQuery[uint32](
 		"Model_MultiKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -391,9 +410,10 @@ func (n *Model_MultiKey_Key1PathAny) State() ygnmi.WildcardQuery[uint32] {
 //	Path from parent:     "config/key1"
 //	Path from root:       "/model/b/multi-key/config/key1"
 func (n *Model_MultiKey_Key1Path) Config() ygnmi.ConfigQuery[uint32] {
-	return ygnmi.NewLeafConfigQuery[uint32](
+	return ygnmi.NewConfigQuery[uint32](
 		"Model_MultiKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "key1"},
@@ -416,6 +436,7 @@ func (n *Model_MultiKey_Key1Path) Config() ygnmi.ConfigQuery[uint32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -426,9 +447,10 @@ func (n *Model_MultiKey_Key1Path) Config() ygnmi.ConfigQuery[uint32] {
 //	Path from parent:     "config/key1"
 //	Path from root:       "/model/b/multi-key/config/key1"
 func (n *Model_MultiKey_Key1PathAny) Config() ygnmi.WildcardQuery[uint32] {
-	return ygnmi.NewLeafWildcardQuery[uint32](
+	return ygnmi.NewWildcardQuery[uint32](
 		"Model_MultiKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "key1"},
@@ -473,8 +495,9 @@ type Model_MultiKey_Key2PathAny struct {
 //	Path from parent:     "state/key2"
 //	Path from root:       "/model/b/multi-key/state/key2"
 func (n *Model_MultiKey_Key2Path) State() ygnmi.SingletonQuery[uint64] {
-	return ygnmi.NewLeafSingletonQuery[uint64](
+	return ygnmi.NewSingletonQuery[uint64](
 		"Model_MultiKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -498,6 +521,7 @@ func (n *Model_MultiKey_Key2Path) State() ygnmi.SingletonQuery[uint64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -508,8 +532,9 @@ func (n *Model_MultiKey_Key2Path) State() ygnmi.SingletonQuery[uint64] {
 //	Path from parent:     "state/key2"
 //	Path from root:       "/model/b/multi-key/state/key2"
 func (n *Model_MultiKey_Key2PathAny) State() ygnmi.WildcardQuery[uint64] {
-	return ygnmi.NewLeafWildcardQuery[uint64](
+	return ygnmi.NewWildcardQuery[uint64](
 		"Model_MultiKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -543,9 +568,10 @@ func (n *Model_MultiKey_Key2PathAny) State() ygnmi.WildcardQuery[uint64] {
 //	Path from parent:     "config/key2"
 //	Path from root:       "/model/b/multi-key/config/key2"
 func (n *Model_MultiKey_Key2Path) Config() ygnmi.ConfigQuery[uint64] {
-	return ygnmi.NewLeafConfigQuery[uint64](
+	return ygnmi.NewConfigQuery[uint64](
 		"Model_MultiKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "key2"},
@@ -568,6 +594,7 @@ func (n *Model_MultiKey_Key2Path) Config() ygnmi.ConfigQuery[uint64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -578,9 +605,10 @@ func (n *Model_MultiKey_Key2Path) Config() ygnmi.ConfigQuery[uint64] {
 //	Path from parent:     "config/key2"
 //	Path from root:       "/model/b/multi-key/config/key2"
 func (n *Model_MultiKey_Key2PathAny) Config() ygnmi.WildcardQuery[uint64] {
-	return ygnmi.NewLeafWildcardQuery[uint64](
+	return ygnmi.NewWildcardQuery[uint64](
 		"Model_MultiKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "key2"},
@@ -686,10 +714,13 @@ func (n *Model_MultiKeyPathAny) Key2() *Model_MultiKey_Key2PathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_MultiKeyPath) State() ygnmi.SingletonQuery[*oc.Model_MultiKey] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_MultiKey](
+	return ygnmi.NewSingletonQuery[*oc.Model_MultiKey](
 		"Model_MultiKey",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -698,15 +729,20 @@ func (n *Model_MultiKeyPath) State() ygnmi.SingletonQuery[*oc.Model_MultiKey] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_MultiKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_MultiKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_MultiKey](
+	return ygnmi.NewWildcardQuery[*oc.Model_MultiKey](
 		"Model_MultiKey",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -719,10 +755,13 @@ func (n *Model_MultiKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_MultiKey] 
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Model_MultiKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_MultiKey] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Model_MultiKey](
+	return ygnmi.NewConfigQuery[*oc.Model_MultiKey](
 		"Model_MultiKey",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -731,15 +770,20 @@ func (n *Model_MultiKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_MultiKey] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Model_MultiKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_MultiKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_MultiKey](
+	return ygnmi.NewWildcardQuery[*oc.Model_MultiKey](
 		"Model_MultiKey",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -762,10 +806,13 @@ type Model_NoKeyPathAny struct {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_NoKeyPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_NoKey](
+	return ygnmi.NewSingletonQuery[*oc.Model_NoKey](
 		"Model_NoKey",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -774,15 +821,20 @@ func (n *Model_NoKeyPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_NoKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_NoKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_NoKey](
+	return ygnmi.NewWildcardQuery[*oc.Model_NoKey](
 		"Model_NoKey",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -812,8 +864,9 @@ type Model_NoKey_Foo_KeyPathAny struct {
 //	Path from parent:     "state/key"
 //	Path from root:       "/model/c/no-key/foo/state/key"
 func (n *Model_NoKey_Foo_KeyPath) State() ygnmi.SingletonQuery[string] {
-	return ygnmi.NewLeafSingletonQuery[string](
+	return ygnmi.NewSingletonQuery[string](
 		"Model_NoKey_Foo",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -837,6 +890,7 @@ func (n *Model_NoKey_Foo_KeyPath) State() ygnmi.SingletonQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -847,8 +901,9 @@ func (n *Model_NoKey_Foo_KeyPath) State() ygnmi.SingletonQuery[string] {
 //	Path from parent:     "state/key"
 //	Path from root:       "/model/c/no-key/foo/state/key"
 func (n *Model_NoKey_Foo_KeyPathAny) State() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"Model_NoKey_Foo",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -894,8 +949,9 @@ type Model_NoKey_Foo_ValuePathAny struct {
 //	Path from parent:     "state/value"
 //	Path from root:       "/model/c/no-key/foo/state/value"
 func (n *Model_NoKey_Foo_ValuePath) State() ygnmi.SingletonQuery[int64] {
-	return ygnmi.NewLeafSingletonQuery[int64](
+	return ygnmi.NewSingletonQuery[int64](
 		"Model_NoKey_Foo",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -919,6 +975,7 @@ func (n *Model_NoKey_Foo_ValuePath) State() ygnmi.SingletonQuery[int64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -929,8 +986,9 @@ func (n *Model_NoKey_Foo_ValuePath) State() ygnmi.SingletonQuery[int64] {
 //	Path from parent:     "state/value"
 //	Path from root:       "/model/c/no-key/foo/state/value"
 func (n *Model_NoKey_Foo_ValuePathAny) State() ygnmi.WildcardQuery[int64] {
-	return ygnmi.NewLeafWildcardQuery[int64](
+	return ygnmi.NewWildcardQuery[int64](
 		"Model_NoKey_Foo",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1037,10 +1095,13 @@ func (n *Model_NoKey_FooPathAny) Value() *Model_NoKey_Foo_ValuePathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_NoKey_FooPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey_Foo] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_NoKey_Foo](
+	return ygnmi.NewSingletonQuery[*oc.Model_NoKey_Foo](
 		"Model_NoKey_Foo",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1049,15 +1110,20 @@ func (n *Model_NoKey_FooPath) State() ygnmi.SingletonQuery[*oc.Model_NoKey_Foo] 
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_NoKey_FooPathAny) State() ygnmi.WildcardQuery[*oc.Model_NoKey_Foo] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_NoKey_Foo](
+	return ygnmi.NewWildcardQuery[*oc.Model_NoKey_Foo](
 		"Model_NoKey_Foo",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1087,8 +1153,9 @@ type Model_SingleKey_KeyPathAny struct {
 //	Path from parent:     "state/key"
 //	Path from root:       "/model/a/single-key/state/key"
 func (n *Model_SingleKey_KeyPath) State() ygnmi.SingletonQuery[string] {
-	return ygnmi.NewLeafSingletonQuery[string](
+	return ygnmi.NewSingletonQuery[string](
 		"Model_SingleKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1112,6 +1179,7 @@ func (n *Model_SingleKey_KeyPath) State() ygnmi.SingletonQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1122,8 +1190,9 @@ func (n *Model_SingleKey_KeyPath) State() ygnmi.SingletonQuery[string] {
 //	Path from parent:     "state/key"
 //	Path from root:       "/model/a/single-key/state/key"
 func (n *Model_SingleKey_KeyPathAny) State() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"Model_SingleKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1157,9 +1226,10 @@ func (n *Model_SingleKey_KeyPathAny) State() ygnmi.WildcardQuery[string] {
 //	Path from parent:     "config/key"
 //	Path from root:       "/model/a/single-key/config/key"
 func (n *Model_SingleKey_KeyPath) Config() ygnmi.ConfigQuery[string] {
-	return ygnmi.NewLeafConfigQuery[string](
+	return ygnmi.NewConfigQuery[string](
 		"Model_SingleKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "key"},
@@ -1182,6 +1252,7 @@ func (n *Model_SingleKey_KeyPath) Config() ygnmi.ConfigQuery[string] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1192,9 +1263,10 @@ func (n *Model_SingleKey_KeyPath) Config() ygnmi.ConfigQuery[string] {
 //	Path from parent:     "config/key"
 //	Path from root:       "/model/a/single-key/config/key"
 func (n *Model_SingleKey_KeyPathAny) Config() ygnmi.WildcardQuery[string] {
-	return ygnmi.NewLeafWildcardQuery[string](
+	return ygnmi.NewWildcardQuery[string](
 		"Model_SingleKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "key"},
@@ -1239,8 +1311,9 @@ type Model_SingleKey_ValuePathAny struct {
 //	Path from parent:     "state/value"
 //	Path from root:       "/model/a/single-key/state/value"
 func (n *Model_SingleKey_ValuePath) State() ygnmi.SingletonQuery[int64] {
-	return ygnmi.NewLeafSingletonQuery[int64](
+	return ygnmi.NewSingletonQuery[int64](
 		"Model_SingleKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1264,6 +1337,7 @@ func (n *Model_SingleKey_ValuePath) State() ygnmi.SingletonQuery[int64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1274,8 +1348,9 @@ func (n *Model_SingleKey_ValuePath) State() ygnmi.SingletonQuery[int64] {
 //	Path from parent:     "state/value"
 //	Path from root:       "/model/a/single-key/state/value"
 func (n *Model_SingleKey_ValuePathAny) State() ygnmi.WildcardQuery[int64] {
-	return ygnmi.NewLeafWildcardQuery[int64](
+	return ygnmi.NewWildcardQuery[int64](
 		"Model_SingleKey",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -1309,9 +1384,10 @@ func (n *Model_SingleKey_ValuePathAny) State() ygnmi.WildcardQuery[int64] {
 //	Path from parent:     "config/value"
 //	Path from root:       "/model/a/single-key/config/value"
 func (n *Model_SingleKey_ValuePath) Config() ygnmi.ConfigQuery[int64] {
-	return ygnmi.NewLeafConfigQuery[int64](
+	return ygnmi.NewConfigQuery[int64](
 		"Model_SingleKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "value"},
@@ -1334,6 +1410,7 @@ func (n *Model_SingleKey_ValuePath) Config() ygnmi.ConfigQuery[int64] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -1344,9 +1421,10 @@ func (n *Model_SingleKey_ValuePath) Config() ygnmi.ConfigQuery[int64] {
 //	Path from parent:     "config/value"
 //	Path from root:       "/model/a/single-key/config/value"
 func (n *Model_SingleKey_ValuePathAny) Config() ygnmi.WildcardQuery[int64] {
-	return ygnmi.NewLeafWildcardQuery[int64](
+	return ygnmi.NewWildcardQuery[int64](
 		"Model_SingleKey",
 		false,
+		true,
 		true,
 		ygnmi.NewNodePath(
 			[]string{"config", "value"},
@@ -1452,10 +1530,13 @@ func (n *Model_SingleKeyPathAny) Value() *Model_SingleKey_ValuePathAny {
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_SingleKeyPath) State() ygnmi.SingletonQuery[*oc.Model_SingleKey] {
-	return ygnmi.NewNonLeafSingletonQuery[*oc.Model_SingleKey](
+	return ygnmi.NewSingletonQuery[*oc.Model_SingleKey](
 		"Model_SingleKey",
 		true,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1464,15 +1545,20 @@ func (n *Model_SingleKeyPath) State() ygnmi.SingletonQuery[*oc.Model_SingleKey] 
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
 func (n *Model_SingleKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_SingleKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_SingleKey](
+	return ygnmi.NewWildcardQuery[*oc.Model_SingleKey](
 		"Model_SingleKey",
 		true,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -1485,10 +1571,13 @@ func (n *Model_SingleKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_SingleKey
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Model_SingleKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_SingleKey] {
-	return ygnmi.NewNonLeafConfigQuery[*oc.Model_SingleKey](
+	return ygnmi.NewConfigQuery[*oc.Model_SingleKey](
 		"Model_SingleKey",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -1497,15 +1586,20 @@ func (n *Model_SingleKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_SingleKey] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Model_SingleKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_SingleKey] {
-	return ygnmi.NewNonLeafWildcardQuery[*oc.Model_SingleKey](
+	return ygnmi.NewWildcardQuery[*oc.Model_SingleKey](
 		"Model_SingleKey",
 		false,
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},

--- a/pathgen/gnmigen.go
+++ b/pathgen/gnmigen.go
@@ -172,9 +172,10 @@ var (
 // 	Path from parent:     "{{ .RelPath }}"
 // 	Path from root:       "{{ .AbsPath }}"
 func (n *{{ .PathStructName }}) {{ .MethodName }}() ygnmi.{{ .SingletonTypeName }}[{{ .GoTypeName }}] {
-	return ygnmi.NewLeaf{{ .SingletonTypeName }}[{{ .GoTypeName }}](
+	return ygnmi.New{{ .SingletonTypeName }}[{{ .GoTypeName }}](
 		"{{ .GoStructTypeName }}",
 		{{ .IsState }},
+		true,
 		{{ .IsScalar }},
 		ygnmi.New{{ .PathBaseTypeName }}(
 			[]string{ {{- .RelPathList -}} },
@@ -205,6 +206,7 @@ func (n *{{ .PathStructName }}) {{ .MethodName }}() ygnmi.{{ .SingletonTypeName 
 				Unmarshal:  {{ .SchemaStructPkgAccessor }}Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -216,9 +218,10 @@ func (n *{{ .PathStructName }}) {{ .MethodName }}() ygnmi.{{ .SingletonTypeName 
 // 	Path from parent:     "{{ .RelPath }}"
 // 	Path from root:       "{{ .AbsPath }}"
 func (n *{{ .PathStructName }}{{ .WildcardSuffix }}) {{ .MethodName }}() ygnmi.{{ .WildcardTypeName }}[{{ .GoTypeName }}] {
-	return ygnmi.NewLeaf{{ .WildcardTypeName }}[{{ .GoTypeName }}](
+	return ygnmi.New{{ .WildcardTypeName }}[{{ .GoTypeName }}](
 		"{{ .GoStructTypeName }}",
 		{{ .IsState }},
+		true,
 		{{ .IsScalar }},
 		ygnmi.New{{ .PathBaseTypeName }}(
 			[]string{ {{- .RelPathList -}} },
@@ -257,10 +260,13 @@ func (n *{{ .PathStructName }}{{ .WildcardSuffix }}) {{ .MethodName }}() ygnmi.{
 	goGNMINonLeafTemplate = mustTemplate("non-leaf-gnmi", `
 // {{ .MethodName }} returns a Query that can be used in gNMI operations.
 func (n *{{ .PathStructName }}) {{ .MethodName }}() ygnmi.{{ .SingletonTypeName }}[{{ .GoTypeName }}] {
-	return ygnmi.NewNonLeaf{{ .SingletonTypeName }}[{{ .GoTypeName }}](
+	return ygnmi.New{{ .SingletonTypeName }}[{{ .GoTypeName }}](
 		"{{ .GoStructTypeName }}",
 		{{ .IsState }},
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -269,6 +275,7 @@ func (n *{{ .PathStructName }}) {{ .MethodName }}() ygnmi.{{ .SingletonTypeName 
 				Unmarshal:  {{ .SchemaStructPkgAccessor }}Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -276,10 +283,14 @@ func (n *{{ .PathStructName }}) {{ .MethodName }}() ygnmi.{{ .SingletonTypeName 
 
 // {{ .MethodName }} returns a Query that can be used in gNMI operations.
 func (n *{{ .PathStructName }}{{ .WildcardSuffix }}) {{ .MethodName }}() ygnmi.{{ .WildcardTypeName }}[{{ .GoTypeName }}] {
-	return ygnmi.NewNonLeaf{{ .WildcardTypeName }}[{{ .GoTypeName }}](
+	return ygnmi.New{{ .WildcardTypeName }}[{{ .GoTypeName }}](
 		"{{ .GoStructTypeName }}",
 		{{ .IsState }},
+		false,
+		false,
 		n,
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &{{ .SchemaStructPkgAccessor }}{{ .FakeRootName }}{},
@@ -311,11 +322,14 @@ func (b *Batch) AddPaths(paths ...ygnmi.PathStruct) *Batch {
 func (b *Batch) State() ygnmi.{{ .SingletonTypeName }}[{{ .GoTypeName }}] {
 	queryPaths := make([]ygnmi.PathStruct, len(b.paths))
 	copy(queryPaths, b.paths)
-    return ygnmi.NewNonLeaf{{ .SingletonTypeName }}[{{ .GoTypeName }}](
-        "{{ .GoStructTypeName }}",
-        true,
-        ygnmi.NewDeviceRootBase(),
-        queryPaths,
+	return ygnmi.New{{ .SingletonTypeName }}[{{ .GoTypeName }}](
+		"{{ .GoStructTypeName }}",
+		true,
+		false,
+		false,
+		ygnmi.NewDeviceRootBase(),
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &{{ .SchemaStructPkgAccessor }}{{ .FakeRootName }}{},
@@ -323,7 +337,8 @@ func (b *Batch) State() ygnmi.{{ .SingletonTypeName }}[{{ .GoTypeName }}] {
 				Unmarshal:  {{ .SchemaStructPkgAccessor }}Unmarshal,
 			}
 		},
-    )
+		queryPaths,
+	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
@@ -331,11 +346,14 @@ func (b *Batch) State() ygnmi.{{ .SingletonTypeName }}[{{ .GoTypeName }}] {
 func (b *Batch) Config() ygnmi.{{ .SingletonTypeName }}[*oc.Root] {
 	queryPaths := make([]ygnmi.PathStruct, len(b.paths))
 	copy(queryPaths, b.paths)
-    return ygnmi.NewNonLeaf{{ .SingletonTypeName }}[*oc.Root](
-        "{{ .GoStructTypeName }}",
-        false,
-        ygnmi.NewDeviceRootBase(),
-        queryPaths,
+	return ygnmi.New{{ .SingletonTypeName }}[*oc.Root](
+		"{{ .GoStructTypeName }}",
+		false,
+		false,
+		false,
+		ygnmi.NewDeviceRootBase(),
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &{{ .SchemaStructPkgAccessor }}{{ .FakeRootName }}{},
@@ -343,7 +361,8 @@ func (b *Batch) Config() ygnmi.{{ .SingletonTypeName }}[*oc.Root] {
 				Unmarshal:  {{ .SchemaStructPkgAccessor }}Unmarshal,
 			}
 		},
-    )
+		queryPaths,
+	)
 }
 `)
 	oncePerPackageTmpl = mustTemplate("once-per-package", `

--- a/pathgen/gnmigen_test.go
+++ b/pathgen/gnmigen_test.go
@@ -62,8 +62,9 @@ func TestGNMIGenerator(t *testing.T) {
 // 	Path from parent:     "leaf"
 // 	Path from root:       "/container/leaf"
 func (n *Container_Leaf) State() ygnmi.SingletonQuery[int32] {
-	return ygnmi.NewLeafSingletonQuery[int32](
+	return ygnmi.NewSingletonQuery[int32](
 		"Container",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -87,6 +88,7 @@ func (n *Container_Leaf) State() ygnmi.SingletonQuery[int32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -96,8 +98,9 @@ func (n *Container_Leaf) State() ygnmi.SingletonQuery[int32] {
 // 	Path from parent:     "leaf"
 // 	Path from root:       "/container/leaf"
 func (n *Container_LeafAny) State() ygnmi.WildcardQuery[int32] {
-	return ygnmi.NewLeafWildcardQuery[int32](
+	return ygnmi.NewWildcardQuery[int32](
 		"Container",
+		true,
 		true,
 		true,
 		ygnmi.NewNodePath(
@@ -157,8 +160,9 @@ func binarySliceToFloatSlice(in []oc.Binary) []float32 {
 // 	Path from parent:     "state/leaflist"
 // 	Path from root:       "/container-with-config/state/leaflist"
 func (n *Container_LeafList) State() ygnmi.SingletonQuery[[]uint32] {
-	return ygnmi.NewLeafSingletonQuery[[]uint32](
+	return ygnmi.NewSingletonQuery[[]uint32](
 		"Container",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -178,6 +182,7 @@ func (n *Container_LeafList) State() ygnmi.SingletonQuery[[]uint32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -187,8 +192,9 @@ func (n *Container_LeafList) State() ygnmi.SingletonQuery[[]uint32] {
 // 	Path from parent:     "state/leaflist"
 // 	Path from root:       "/container-with-config/state/leaflist"
 func (n *Container_LeafListAny) State() ygnmi.WildcardQuery[[]uint32] {
-	return ygnmi.NewLeafWildcardQuery[[]uint32](
+	return ygnmi.NewWildcardQuery[[]uint32](
 		"Container",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -217,9 +223,10 @@ func (n *Container_LeafListAny) State() ygnmi.WildcardQuery[[]uint32] {
 // 	Path from parent:     "config/leaflist"
 // 	Path from root:       "/container-with-config/config/leaflist"
 func (n *Container_LeafList) Config() ygnmi.ConfigQuery[[]uint32] {
-	return ygnmi.NewLeafConfigQuery[[]uint32](
+	return ygnmi.NewConfigQuery[[]uint32](
 		"Container",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "leaflist"},
@@ -238,6 +245,7 @@ func (n *Container_LeafList) Config() ygnmi.ConfigQuery[[]uint32] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -247,9 +255,10 @@ func (n *Container_LeafList) Config() ygnmi.ConfigQuery[[]uint32] {
 // 	Path from parent:     "config/leaflist"
 // 	Path from root:       "/container-with-config/config/leaflist"
 func (n *Container_LeafListAny) Config() ygnmi.WildcardQuery[[]uint32] {
-	return ygnmi.NewLeafWildcardQuery[[]uint32](
+	return ygnmi.NewWildcardQuery[[]uint32](
 		"Container",
 		false,
+		true,
 		false,
 		ygnmi.NewNodePath(
 			[]string{"config", "leaflist"},
@@ -293,8 +302,9 @@ func (n *Container_LeafListAny) Config() ygnmi.WildcardQuery[[]uint32] {
 // 	Path from parent:     "leaf"
 // 	Path from root:       "/container/leaf"
 func (n *Container_Leaf) State() ygnmi.SingletonQuery[E_Child_Three] {
-	return ygnmi.NewLeafSingletonQuery[E_Child_Three](
+	return ygnmi.NewSingletonQuery[E_Child_Three](
 		"Container",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -314,6 +324,7 @@ func (n *Container_Leaf) State() ygnmi.SingletonQuery[E_Child_Three] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 
@@ -323,8 +334,9 @@ func (n *Container_Leaf) State() ygnmi.SingletonQuery[E_Child_Three] {
 // 	Path from parent:     "leaf"
 // 	Path from root:       "/container/leaf"
 func (n *Container_LeafAny) State() ygnmi.WildcardQuery[E_Child_Three] {
-	return ygnmi.NewLeafWildcardQuery[E_Child_Three](
+	return ygnmi.NewWildcardQuery[E_Child_Three](
 		"Container",
+		true,
 		true,
 		false,
 		ygnmi.NewNodePath(
@@ -381,11 +393,14 @@ func (b *Batch) AddPaths(paths ...ygnmi.PathStruct) *Batch {
 func (b *Batch) State() ygnmi.SingletonQuery[*Root] {
 	queryPaths := make([]ygnmi.PathStruct, len(b.paths))
 	copy(queryPaths, b.paths)
-    return ygnmi.NewNonLeafSingletonQuery[*Root](
-        "Root",
-        true,
-        ygnmi.NewDeviceRootBase(),
-        queryPaths,
+	return ygnmi.NewSingletonQuery[*Root](
+		"Root",
+		true,
+		false,
+		false,
+		ygnmi.NewDeviceRootBase(),
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -393,7 +408,8 @@ func (b *Batch) State() ygnmi.SingletonQuery[*Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
-    )
+		queryPaths,
+	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
@@ -401,27 +417,13 @@ func (b *Batch) State() ygnmi.SingletonQuery[*Root] {
 func (b *Batch) Config() ygnmi.SingletonQuery[*oc.Root] {
 	queryPaths := make([]ygnmi.PathStruct, len(b.paths))
 	copy(queryPaths, b.paths)
-    return ygnmi.NewNonLeafSingletonQuery[*oc.Root](
-        "Root",
-        false,
-        ygnmi.NewDeviceRootBase(),
-        queryPaths,
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-    )
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *Root) State() ygnmi.SingletonQuery[*Root] {
-	return ygnmi.NewNonLeafSingletonQuery[*Root](
+	return ygnmi.NewSingletonQuery[*oc.Root](
 		"Root",
-		true,
-		n,
+		false,
+		false,
+		false,
+		ygnmi.NewDeviceRootBase(),
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -430,15 +432,40 @@ func (n *Root) State() ygnmi.SingletonQuery[*Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		queryPaths,
+	)
+}
+
+// State returns a Query that can be used in gNMI operations.
+func (n *Root) State() ygnmi.SingletonQuery[*Root] {
+	return ygnmi.NewSingletonQuery[*Root](
+		"Root",
+		true,
+		false,
+		false,
+		n,
+		nil,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+		nil,
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
 func (n *Root) Config() ygnmi.ConfigQuery[*Root] {
-	return ygnmi.NewNonLeafConfigQuery[*Root](
+	return ygnmi.NewConfigQuery[*Root](
 		"Root",
 		false,
+		false,
+		false,
 		n,
+		nil,
 		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
@@ -447,6 +474,7 @@ func (n *Root) Config() ygnmi.ConfigQuery[*Root] {
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
+		nil,
 	)
 }
 `,

--- a/schemaless/schemaless.go
+++ b/schemaless/schemaless.go
@@ -39,15 +39,18 @@ func NewConfig[T any](path, origin string) (ygnmi.ConfigQuery[T], error) {
 		return nil, err
 	}
 
-	return ygnmi.NewLeafConfigQuery("",
+	return ygnmi.NewConfigQuery("",
 			false,
+			true,
 			scalar,
 			ps,
 			createFn,
 			func() ygot.ValidatedGoStruct {
 				return nil
 			},
-			func() *ytypes.Schema { return nil }),
+			func() *ytypes.Schema { return nil },
+			nil,
+		),
 		nil
 }
 
@@ -59,15 +62,17 @@ func NewWildcard[T any](path, origin string) (ygnmi.WildcardQuery[T], error) {
 		return nil, err
 	}
 
-	return ygnmi.NewLeafWildcardQuery("",
+	return ygnmi.NewWildcardQuery("",
 			false,
+			true,
 			scalar,
 			ps,
 			createFn,
 			func() ygot.ValidatedGoStruct {
 				return nil
 			},
-			func() *ytypes.Schema { return nil }),
+			func() *ytypes.Schema { return nil },
+		),
 		nil
 }
 

--- a/ygnmi/types.go
+++ b/ygnmi/types.go
@@ -22,129 +22,89 @@ import (
 	"github.com/openconfig/ygot/ytypes"
 )
 
-func newBaseQuery[T any](dir string, state bool, ps PathStruct, schemaFn func() *ytypes.Schema) baseQuery[T] {
-	return baseQuery[T]{
-		goStructName: dir,
-		state:        state,
-		ps:           ps,
-		yschemaFn:    schemaFn,
-	}
-}
-
-// NewLeafSingletonQuery creates a new LeafSingletonQuery object.
-func NewLeafSingletonQuery[T any](parentDir string, state, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema) *LeafSingletonQuery[T] {
-	return &LeafSingletonQuery[T]{
-		leafBaseQuery: leafBaseQuery[T]{
-			baseQuery: newBaseQuery[T](
-				parentDir,
-				state,
-				ps,
-				schemaFn,
-			),
-			scalar:     scalar,
-			extractFn:  extractFn,
-			goStructFn: goStructFn,
-		},
-	}
-}
-
-// NewNonLeafSingletonQuery creates a new NonLeafSingletonQuery object.
-func NewNonLeafSingletonQuery[T ygot.ValidatedGoStruct](dir string, state bool, ps PathStruct, subPaths []PathStruct, schemaFn func() *ytypes.Schema) *NonLeafSingletonQuery[T] {
-	return &NonLeafSingletonQuery[T]{
-		nonLeafBaseQuery: nonLeafBaseQuery[T]{
-			baseQuery: newBaseQuery[T](
-				dir,
-				state,
-				ps,
-				schemaFn,
-			),
-			queryPathStructs: subPaths,
-		},
-	}
-}
-
-// NewLeafConfigQuery creates a new NewLeafConfigQuery object.
-func NewLeafConfigQuery[T any](parentDir string, state, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema) *LeafConfigQuery[T] {
-	return &LeafConfigQuery[T]{
-		leafBaseQuery: leafBaseQuery[T]{
-			baseQuery: newBaseQuery[T](
-				parentDir,
-				state,
-				ps,
-				schemaFn,
-			),
-			scalar:     scalar,
-			extractFn:  extractFn,
-			goStructFn: goStructFn,
-		},
-	}
-}
-
-// NewNonLeafConfigQuery creates a new NewNonLeafConfigQuery object.
-func NewNonLeafConfigQuery[T ygot.ValidatedGoStruct](dir string, state bool, ps PathStruct, subPaths []PathStruct, schemaFn func() *ytypes.Schema) *NonLeafConfigQuery[T] {
-	return &NonLeafConfigQuery[T]{
-		nonLeafBaseQuery: nonLeafBaseQuery[T]{
-			baseQuery: newBaseQuery[T](
-				dir,
-				state,
-				ps,
-				schemaFn,
-			),
-		},
-	}
-}
-
-// NewLeafWildcardQuery creates a new NewLeafWildcardQuery object.
-func NewLeafWildcardQuery[T any](parentDir string, state, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema) *LeafWildcardQuery[T] {
-	return &LeafWildcardQuery[T]{
-		leafBaseQuery: leafBaseQuery[T]{
-			baseQuery: newBaseQuery[T](
-				parentDir,
-				state,
-				ps,
-				schemaFn,
-			),
-			scalar:     scalar,
-			extractFn:  extractFn,
-			goStructFn: goStructFn,
-		},
-	}
-}
-
-// NewNonLeafWildcardQuery creates a new NewNonLeafWildcardQuery object.
-func NewNonLeafWildcardQuery[T ygot.ValidatedGoStruct](dir string, state bool, ps PathStruct, schemaFn func() *ytypes.Schema) *NonLeafWildcardQuery[T] {
-	return &NonLeafWildcardQuery[T]{
-		nonLeafBaseQuery: nonLeafBaseQuery[T]{
-			baseQuery: newBaseQuery[T](
-				dir,
-				state,
-				ps,
-				schemaFn,
-			),
-		},
-	}
-}
-
 // ExtractFn is the type for the func that extracts a concrete val from a GoStruct.
 type ExtractFn[T any] func(ygot.ValidatedGoStruct) (T, bool)
 
-// LeafSingletonQuery is implementation of SingletonQuery interface for leaf nodes.
+// NewSingletonQuery creates a new SingletonQueryStruct object.
+func NewSingletonQuery[T any](goStructName string, state, leaf, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema, subPaths []PathStruct) *SingletonQueryStruct[T] {
+	return &SingletonQueryStruct[T]{
+		baseQuery: baseQuery[T]{
+			goStructName,
+			state,
+			ps,
+			leaf,
+			scalar,
+			schemaFn,
+			extractFn,
+			goStructFn,
+			subPaths,
+		},
+	}
+}
+
+// NewConfigQuery creates a new NewLeafConfigQuery object.
+func NewConfigQuery[T any](goStructName string, state, leaf, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema, subPaths []PathStruct) *ConfigQueryStruct[T] {
+	return &ConfigQueryStruct[T]{
+		baseQuery: baseQuery[T]{
+			goStructName,
+			state,
+			ps,
+			leaf,
+			scalar,
+			schemaFn,
+			extractFn,
+			goStructFn,
+			nil,
+		},
+	}
+}
+
+// NewWildcardQuery creates a new NewLeafWildcardQuery object.
+func NewWildcardQuery[T any](goStructName string, state, leaf, scalar bool, ps PathStruct, extractFn ExtractFn[T], goStructFn func() ygot.ValidatedGoStruct, schemaFn func() *ytypes.Schema) *WildcardQueryStruct[T] {
+	return &WildcardQueryStruct[T]{
+		baseQuery: baseQuery[T]{
+			goStructName,
+			state,
+			ps,
+			leaf,
+			scalar,
+			schemaFn,
+			extractFn,
+			goStructFn,
+			nil,
+		},
+	}
+}
+
+// SingletonQueryStruct is implementation of SingletonQuery interface.
 // Note: Do not use this type directly, instead use the generated Path API.
-type LeafSingletonQuery[T any] struct {
-	leafBaseQuery[T]
+type SingletonQueryStruct[T any] struct {
+	baseQuery[T]
 }
 
 // IsSingleton prevents this struct from being used where a wildcard path is expected.
-func (lq *LeafSingletonQuery[T]) IsSingleton() {}
+func (q *SingletonQueryStruct[T]) IsSingleton() {}
 
-// LeafWildcardQuery is implementation of SingletonQuery interface for leaf nodes.
+// WildcardQueryStruct is implementation of SingletonQuery interface for leaf nodes.
 // Note: Do not use this type directly, instead use the generated Path API.
-type LeafWildcardQuery[T any] struct {
-	leafBaseQuery[T]
+type WildcardQueryStruct[T any] struct {
+	baseQuery[T]
 }
 
 // IsWildcard prevents this struct from being used where a non wildcard path is expected.
-func (lq *LeafWildcardQuery[T]) IsWildcard() {}
+func (q *WildcardQueryStruct[T]) IsWildcard() {}
+
+// ConfigQueryStruct is implementation of ConfigQuery interface for leaf nodes.
+// Note: Do not use this type directly, instead use the generated Path API.
+type ConfigQueryStruct[T any] struct {
+	baseQuery[T]
+}
+
+// IsConfig restricts this struct to be used only where a config path is expected.
+func (q *ConfigQueryStruct[T]) IsConfig() {}
+
+// IsSingleton restricts this struct to be used only where a singleton path is expected.
+func (q *ConfigQueryStruct[T]) IsSingleton() {}
 
 type baseQuery[T any] struct {
 	// goStructName is the name of the YANG directory or GoStruct which
@@ -157,8 +117,19 @@ type baseQuery[T any] struct {
 	state bool
 	// ps contains the path specification of the query.
 	ps PathStruct
+	// leaf indicates whether the query is on a leaf node.
+	leaf bool
+	// scalar is whether the type (T) for this path is a pointer field (*T) in the parent GoStruct.
+	scalar bool
 	// yschemaFn is parsed YANG schema to use when unmarshalling data.
 	yschemaFn func() *ytypes.Schema
+	// extractFn is used to extract the value from the containing GoStruct.
+	extractFn ExtractFn[T]
+	// goStructFn initializes a new GoStruct containing this node.
+	goStructFn func() ygot.ValidatedGoStruct
+	// queryPathStructs are the paths used to for the gNMI subscription.
+	// They must be equal to or descendants of ps.
+	queryPathStructs []PathStruct
 }
 
 // dirName returns the YANG schema name of the GoStruct containing this node.
@@ -181,19 +152,9 @@ func (q *baseQuery[T]) schema() *ytypes.Schema {
 	return q.yschemaFn()
 }
 
-type leafBaseQuery[T any] struct {
-	baseQuery[T]
-	// extractFn is used to extract the value from the containing GoStruct.
-	extractFn ExtractFn[T]
-	// goStructFn initializes a new GoStruct containing this node.
-	goStructFn func() ygot.ValidatedGoStruct
-	// scalar is whether the type (T) for this path is a pointer field (*T) in the parent GoStruct.
-	scalar bool
-}
-
 // String returns gNMI path as string for the query.
-func (lq *leafBaseQuery[T]) String() string {
-	protoPath, _, err := ResolvePath(lq.ps)
+func (q *baseQuery[T]) String() string {
+	protoPath, _, err := ResolvePath(q.ps)
 	if err != nil {
 		return fmt.Sprintf("invalid path: %v", err)
 	}
@@ -204,79 +165,28 @@ func (lq *leafBaseQuery[T]) String() string {
 	return path
 }
 
-// extract takes the parent GoStruct and returns the correct child field from it.
-func (lq *leafBaseQuery[T]) extract(gs ygot.ValidatedGoStruct) (T, bool) {
-	return lq.extractFn(gs)
-}
-
-// goStruct returns the parent struct of the leaf node.
-func (lq *leafBaseQuery[T]) goStruct() ygot.ValidatedGoStruct {
-	return lq.goStructFn()
-}
-
-// isLeaf returns true, as this Query type is only for leaves.
-func (lq *leafBaseQuery[T]) isLeaf() bool {
-	return true
-}
-
-// subPaths returns the path structs used for creating the gNMI subscription.
-// A leaf subscribes to the same path returned by PathStruct().
-func (lq *leafBaseQuery[T]) subPaths() []PathStruct {
-	return []PathStruct{lq.ps}
-}
-
-// isScalar returns whether the type (T) for this path is a pointer field (*T) in the parent GoStruct.
-func (lq *leafBaseQuery[T]) isScalar() bool {
-	return lq.scalar
-}
-
-// NonLeafSingletonQuery is implementation of SingletonQuery interface for non-leaf nodes.
-// Note: Do not use this type directly, instead use the generated Path API.
-type NonLeafSingletonQuery[T ygot.ValidatedGoStruct] struct {
-	nonLeafBaseQuery[T]
-}
-
-// IsSingleton prevents this struct from being used where a wildcard path is expected.
-func (lq *NonLeafSingletonQuery[T]) IsSingleton() {}
-
-// NonLeafWildcardQuery is implementation of SingletonQuery interface for non-leaf nodes.
-// Note: Do not use this type directly, instead use the generated Path API.
-type NonLeafWildcardQuery[T ygot.ValidatedGoStruct] struct {
-	nonLeafBaseQuery[T]
-}
-
-// IsWildcard prevents this struct from being used where a non-wildcard path is expected.
-func (lq *NonLeafWildcardQuery[T]) IsWildcard() {}
-
-type nonLeafBaseQuery[T ygot.ValidatedGoStruct] struct {
-	baseQuery[T]
-	// queryPathStructs are the paths used to for the gNMI subscription.
-	// They must be equal to or descendants of ps.
-	queryPathStructs []PathStruct
-}
-
-// String returns gNMI path as string for the query.
-func (lq *nonLeafBaseQuery[T]) String() string {
-	protoPath, _, err := ResolvePath(lq.ps)
-	if err != nil {
-		return fmt.Sprintf("invalid path: %v", err)
+// extract extracts the unmarshalled value from the containing GoStruct.
+//
+// For queries on GoStructs it simply casts the input GoStruct to the concrete
+// type for the query.
+//
+// For other types it extracts and returns the correct child field from it.
+func (q *baseQuery[T]) extract(gs ygot.ValidatedGoStruct) (T, bool) {
+	if q.extractFn != nil {
+		return q.extractFn(gs)
 	}
-	path, err := ygot.PathToString(protoPath)
-	if err != nil {
-		path = protoPath.String()
-	}
-	return path
-}
 
-// extract casts the input GoStruct to the concrete type for the query.
-// As non-leaves structs are always GoStructs, a simple cast is sufficient.
-func (lq *nonLeafBaseQuery[T]) extract(gs ygot.ValidatedGoStruct) (T, bool) {
 	val := gs.(T)
 	return val, !reflect.ValueOf(val).Elem().IsZero()
 }
 
-// goStruct returns new initialized GoStruct, gNMI notifications can be unmarshalled into this struct.
-func (lq *nonLeafBaseQuery[T]) goStruct() ygot.ValidatedGoStruct {
+// goStruct returns new empty GoStruct into which gNMI notifications can be
+// unmarshalled.
+func (q *baseQuery[T]) goStruct() ygot.ValidatedGoStruct {
+	if q.goStructFn != nil {
+		return q.goStructFn()
+	}
+
 	// Get the underlying type of T (which is a pointer), deference it to get the base type.
 	// Create a new instance of the base type and return it as a ValidatedGoStruct.
 	var t T
@@ -284,44 +194,22 @@ func (lq *nonLeafBaseQuery[T]) goStruct() ygot.ValidatedGoStruct {
 	return gs.Interface().(ygot.ValidatedGoStruct)
 }
 
-// isLeaf returns false, as this Query type is only for non-leaves.
-func (lq *nonLeafBaseQuery[T]) isLeaf() bool {
-	return false
-}
-
-// isScalar returns false, as non-leafs are always non-scalar objects.
-func (lq *nonLeafBaseQuery[T]) isScalar() bool {
-	return false
+// isLeaf returns whether the query refers to a leaf.
+func (q *baseQuery[T]) isLeaf() bool {
+	return q.leaf
 }
 
 // subPaths returns the path structs used for creating the gNMI subscription.
-func (lq *nonLeafBaseQuery[T]) subPaths() []PathStruct {
-	if len(lq.queryPathStructs) == 0 {
-		return []PathStruct{lq.ps}
+func (q *baseQuery[T]) subPaths() []PathStruct {
+	if len(q.queryPathStructs) == 0 {
+		return []PathStruct{q.ps}
 	}
-	return lq.queryPathStructs
+	return q.queryPathStructs
 }
 
-// LeafConfigQuery is implementation of ConfigQuery interface for leaf nodes.
-// Note: Do not use this type directly, instead use the generated Path API.
-type LeafConfigQuery[T any] struct {
-	leafBaseQuery[T]
+// isScalar returns whether the type (T) for this path is a leaf type that is
+// represented by a pointer field (*T) in the parent GoStruct, but whose
+// natural type is not a pointer (e.g. YANG's string type).
+func (q *baseQuery[T]) isScalar() bool {
+	return q.scalar
 }
-
-// IsConfig restricts this struct to be used only where a config path is expected.
-func (lq *LeafConfigQuery[T]) IsConfig() {}
-
-// IsSingleton restricts this struct to be used only where a singleton path is expected.
-func (lq *LeafConfigQuery[T]) IsSingleton() {}
-
-// NonLeafConfigQuery is implementation of ConfigQuery interface for non-leaf nodes.
-// Note: Do not use this type directly, instead use the generated Path API.
-type NonLeafConfigQuery[T ygot.ValidatedGoStruct] struct {
-	nonLeafBaseQuery[T]
-}
-
-// IsConfig restricts this struct to be used only where a config path is expected.
-func (nlq *NonLeafConfigQuery[T]) IsConfig() {}
-
-// IsSingleton restricts this struct to be used only where a singleton path is expected.
-func (nlq *NonLeafConfigQuery[T]) IsSingleton() {}

--- a/ygnmi/ygnmi.go
+++ b/ygnmi/ygnmi.go
@@ -681,11 +681,15 @@ func (b *Batch[T]) AddPaths(paths ...PathStruct) error {
 func (b *Batch[T]) Query() SingletonQuery[T] {
 	queryPaths := make([]PathStruct, len(b.paths))
 	copy(queryPaths, b.paths)
-	return NewNonLeafSingletonQuery[T](
+	return NewSingletonQuery[T](
 		b.root.dirName(),
 		b.root.IsState(),
+		false,
+		false,
 		b.root.PathStruct(),
-		queryPaths,
+		nil,
+		nil,
 		b.root.schema,
+		queryPaths,
 	)
 }


### PR DESCRIPTION
This change anticipates later changes where there are other types (i.e. ygot.GoOrderedMap) that is neither a leaf nor a GoStruct.