### PR TITLE
Proposal: Generate `Map` method for all keyed lists.

### DIFF
--- a/exampleoc/withlistval/withlistval-0.go
+++ b/exampleoc/withlistval/withlistval-0.go
@@ -1526,13 +1526,13 @@ func (n *Model_SingleKeyPathAny) Key() *Model_SingleKey_KeyPathAny {
 	}
 }
 
-// OrderedListAll (list):
+// OrderedListMap (list):
 //
 //	Defining module:      "openconfig-withlistval"
 //	Instantiating module: "openconfig-withlistval"
 //	Path from parent:     "ordered-lists/ordered-list"
 //	Path from root:       "/model/a/single-key/ordered-lists/ordered-list"
-func (n *Model_SingleKeyPath) OrderedListAll() *Model_SingleKey_OrderedListPath {
+func (n *Model_SingleKeyPath) OrderedListMap() *Model_SingleKey_OrderedListPath {
 	return &Model_SingleKey_OrderedListPath{
 		NodePath: ygnmi.NewNodePath(
 			[]string{"ordered-lists"},
@@ -1542,13 +1542,13 @@ func (n *Model_SingleKeyPath) OrderedListAll() *Model_SingleKey_OrderedListPath 
 	}
 }
 
-// OrderedListAll (list):
+// OrderedListMap (list):
 //
 //	Defining module:      "openconfig-withlistval"
 //	Instantiating module: "openconfig-withlistval"
 //	Path from parent:     "ordered-lists/ordered-list"
 //	Path from root:       "/model/a/single-key/ordered-lists/ordered-list"
-func (n *Model_SingleKeyPathAny) OrderedListAll() *Model_SingleKey_OrderedListPathAny {
+func (n *Model_SingleKeyPathAny) OrderedListMap() *Model_SingleKey_OrderedListPathAny {
 	return &Model_SingleKey_OrderedListPathAny{
 		NodePath: ygnmi.NewNodePath(
 			[]string{"ordered-lists"},

--- a/pathgen/pathgen.go
+++ b/pathgen/pathgen.go
@@ -62,9 +62,9 @@ const (
 	// BuilderCtorSuffix is the suffix applied to the list builder
 	// constructor method's name in order to indicate itself to the user.
 	BuilderCtorSuffix = "Any"
-	// WholeKeyedListCtorSuffix is the suffix applied to a keyed list's
+	// WholedKeyedListSuffix is the suffix applied to a keyed list's
 	// constructor method name in order to indicate itself to the user.
-	WholeKeyedListCtorSuffix = "Map"
+	WholedKeyedListSuffix = "Map"
 	// BuilderKeyPrefix is the prefix applied to the key-modifying builder
 	// method for a list PathStruct that uses the builder API.
 	// NOTE: This cannot be "", as the builder method name would conflict
@@ -1150,7 +1150,7 @@ func generateChildConstructors(methodBuf *strings.Builder, builderBuf *strings.B
 			return []error{fmt.Errorf("expected two path elements for the relative path of an ordered map, got %d: %v", gotLen, path)}
 		}
 		fieldData.RelPathList = relPathListFn(path[:1])
-		fieldData.MethodName += WholeKeyedListCtorSuffix
+		fieldData.MethodName += WholedKeyedListSuffix
 		fallthrough
 	case field.Type != ygen.ListNode:
 		return generateChildConstructorsForLeafOrContainer(methodBuf, fieldData, isUnderFakeRoot, generateWildcardPaths, unified, field.Type == ygen.LeafNode || field.Type == ygen.LeafListNode)

--- a/pathgen/pathgen.go
+++ b/pathgen/pathgen.go
@@ -64,9 +64,6 @@ const (
 	BuilderCtorSuffix = "Any"
 	// WholeKeyedListCtorSuffix is the suffix applied to a keyed list's
 	// constructor method name in order to indicate itself to the user.
-	//
-	// Map is the name chosen since keyed lists are always represented as
-	// maps or ordered maps. Unkeyed lists
 	WholeKeyedListCtorSuffix = "Map"
 	// BuilderKeyPrefix is the prefix applied to the key-modifying builder
 	// method for a list PathStruct that uses the builder API.

--- a/pathgen/pathgen.go
+++ b/pathgen/pathgen.go
@@ -62,9 +62,9 @@ const (
 	// BuilderCtorSuffix is the suffix applied to the list builder
 	// constructor method's name in order to indicate itself to the user.
 	BuilderCtorSuffix = "Any"
-	// WholedKeyedListSuffix is the suffix applied to a keyed list's
+	// WholeKeyedListSuffix is the suffix applied to a keyed list's
 	// constructor method name in order to indicate itself to the user.
-	WholedKeyedListSuffix = "Map"
+	WholeKeyedListSuffix = "Map"
 	// BuilderKeyPrefix is the prefix applied to the key-modifying builder
 	// method for a list PathStruct that uses the builder API.
 	// NOTE: This cannot be "", as the builder method name would conflict
@@ -1150,7 +1150,7 @@ func generateChildConstructors(methodBuf *strings.Builder, builderBuf *strings.B
 			return []error{fmt.Errorf("expected two path elements for the relative path of an ordered map, got %d: %v", gotLen, path)}
 		}
 		fieldData.RelPathList = relPathListFn(path[:1])
-		fieldData.MethodName += WholedKeyedListSuffix
+		fieldData.MethodName += WholeKeyedListSuffix
 		fallthrough
 	case field.Type != ygen.ListNode:
 		return generateChildConstructorsForLeafOrContainer(methodBuf, fieldData, isUnderFakeRoot, generateWildcardPaths, unified, field.Type == ygen.LeafNode || field.Type == ygen.LeafListNode)

--- a/pathgen/pathgen.go
+++ b/pathgen/pathgen.go
@@ -62,9 +62,9 @@ const (
 	// BuilderCtorSuffix is the suffix applied to the list builder
 	// constructor method's name in order to indicate itself to the user.
 	BuilderCtorSuffix = "Any"
-	// OrderedListCtorSuffix is the suffix applied to the ordered list
+	// WholeListCtorSuffix is the suffix applied to the ordered list
 	// constructor method's name in order to indicate itself to the user.
-	OrderedListCtorSuffix = "All"
+	WholeListCtorSuffix = "All"
 	// BuilderKeyPrefix is the prefix applied to the key-modifying builder
 	// method for a list PathStruct that uses the builder API.
 	// NOTE: This cannot be "", as the builder method name would conflict
@@ -1150,7 +1150,7 @@ func generateChildConstructors(methodBuf *strings.Builder, builderBuf *strings.B
 			return []error{fmt.Errorf("expected two path elements for the relative path of an ordered map, got %d: %v", gotLen, path)}
 		}
 		fieldData.RelPathList = relPathListFn(path[:1])
-		fieldData.MethodName += OrderedListCtorSuffix
+		fieldData.MethodName += WholeListCtorSuffix
 		fallthrough
 	case field.Type != ygen.ListNode:
 		return generateChildConstructorsForLeafOrContainer(methodBuf, fieldData, isUnderFakeRoot, generateWildcardPaths, unified, field.Type == ygen.LeafNode || field.Type == ygen.LeafListNode)

--- a/pathgen/pathgen.go
+++ b/pathgen/pathgen.go
@@ -62,9 +62,12 @@ const (
 	// BuilderCtorSuffix is the suffix applied to the list builder
 	// constructor method's name in order to indicate itself to the user.
 	BuilderCtorSuffix = "Any"
-	// WholeListCtorSuffix is the suffix applied to the ordered list
-	// constructor method's name in order to indicate itself to the user.
-	WholeListCtorSuffix = "All"
+	// WholeKeyedListCtorSuffix is the suffix applied to a keyed list's
+	// constructor method name in order to indicate itself to the user.
+	//
+	// Map is the name chosen since keyed lists are always represented as
+	// maps or ordered maps. Unkeyed lists
+	WholeKeyedListCtorSuffix = "Map"
 	// BuilderKeyPrefix is the prefix applied to the key-modifying builder
 	// method for a list PathStruct that uses the builder API.
 	// NOTE: This cannot be "", as the builder method name would conflict
@@ -1150,7 +1153,7 @@ func generateChildConstructors(methodBuf *strings.Builder, builderBuf *strings.B
 			return []error{fmt.Errorf("expected two path elements for the relative path of an ordered map, got %d: %v", gotLen, path)}
 		}
 		fieldData.RelPathList = relPathListFn(path[:1])
-		fieldData.MethodName += WholeListCtorSuffix
+		fieldData.MethodName += WholeKeyedListCtorSuffix
 		fallthrough
 	case field.Type != ygen.ListNode:
 		return generateChildConstructorsForLeafOrContainer(methodBuf, fieldData, isUnderFakeRoot, generateWildcardPaths, unified, field.Type == ygen.LeafNode || field.Type == ygen.LeafListNode)

--- a/pathgen/testdata/structs/openconfig-orderedlist.path-txt
+++ b/pathgen/testdata/structs/openconfig-orderedlist.path-txt
@@ -52,12 +52,12 @@ type ModelPathAny struct {
 	*ygnmi.NodePath
 }
 
-// OrderedListAll (list): 
+// OrderedListMap (list): 
 // 	Defining module:      "openconfig-orderedlist"
 // 	Instantiating module: "openconfig-orderedlist"
 // 	Path from parent:     "ordered-lists/ordered-list"
 // 	Path from root:       "/model/ordered-lists/ordered-list"
-func (n *ModelPath) OrderedListAll() *Model_OrderedListPath {
+func (n *ModelPath) OrderedListMap() *Model_OrderedListPath {
 	return &Model_OrderedListPath{
 		NodePath: ygnmi.NewNodePath(
 			[]string{"ordered-lists"},
@@ -67,12 +67,12 @@ func (n *ModelPath) OrderedListAll() *Model_OrderedListPath {
 	}
 }
 
-// OrderedListAll (list): 
+// OrderedListMap (list): 
 // 	Defining module:      "openconfig-orderedlist"
 // 	Instantiating module: "openconfig-orderedlist"
 // 	Path from parent:     "ordered-lists/ordered-list"
 // 	Path from root:       "/model/ordered-lists/ordered-list"
-func (n *ModelPathAny) OrderedListAll() *Model_OrderedListPathAny {
+func (n *ModelPathAny) OrderedListMap() *Model_OrderedListPathAny {
 	return &Model_OrderedListPathAny{
 		NodePath: ygnmi.NewNodePath(
 			[]string{"ordered-lists"},

--- a/ygnmi/ygnmi_test.go
+++ b/ygnmi/ygnmi_test.go
@@ -587,7 +587,7 @@ func TestLookup(t *testing.T) {
 
 		lookupCheckFn(
 			t, fakeGNMI, c,
-			ygnmi.SingletonQuery[*exampleoc.Model_SingleKey_OrderedList_OrderedMap](exampleocpath.Root().Model().SingleKey("foo").OrderedListAll().Config()),
+			ygnmi.SingletonQuery[*exampleoc.Model_SingleKey_OrderedList_OrderedMap](exampleocpath.Root().Model().SingleKey("foo").OrderedListMap().Config()),
 			"",
 			testutil.GNMIPath(t, "/model/a/single-key[key=foo]/ordered-lists"),
 			(&ygnmi.Value[*exampleoc.Model_SingleKey_OrderedList_OrderedMap]{
@@ -774,7 +774,7 @@ func TestLookupWithGet(t *testing.T) {
 
 		lookupWithGetCheckFn(
 			t, fakeGNMI, c,
-			ygnmi.SingletonQuery[*exampleoc.Model_SingleKey_OrderedList_OrderedMap](exampleocpath.Root().Model().SingleKey("foo").OrderedListAll().Config()),
+			ygnmi.SingletonQuery[*exampleoc.Model_SingleKey_OrderedList_OrderedMap](exampleocpath.Root().Model().SingleKey("foo").OrderedListMap().Config()),
 			"",
 			&gpb.GetRequest{
 				Encoding: gpb.Encoding_JSON_IETF,
@@ -909,7 +909,7 @@ func TestGet(t *testing.T) {
 		}).Sync()
 
 		getCheckFn(t, fakeGNMI, c,
-			exampleocpath.Root().Model().SingleKey("foo").OrderedListAll().State(),
+			exampleocpath.Root().Model().SingleKey("foo").OrderedListMap().State(),
 			"",
 			testutil.GNMIPath(t, "/model/a/single-key[key=foo]/ordered-lists"),
 			getSampleOrderedMap(t),
@@ -1344,7 +1344,7 @@ func TestWatch(t *testing.T) {
 
 		want := getSampleOrderedMap(t)
 		watchCheckFn(t, fakeGNMI, 2*time.Second, client,
-			exampleocpath.Root().Model().SingleKey("foo").OrderedListAll().State(),
+			exampleocpath.Root().Model().SingleKey("foo").OrderedListMap().State(),
 			nil,
 			func(val *exampleoc.Model_SingleKey_OrderedList_OrderedMap) bool {
 				return cmp.Equal(val, want, cmp.AllowUnexported(exampleoc.Model_SingleKey_OrderedList_OrderedMap{}))
@@ -2067,7 +2067,7 @@ func TestLookupAll(t *testing.T) {
 
 		lookupAllCheckFn(
 			t, fakeGNMI, c,
-			exampleocpath.Root().Model().SingleKeyAny().OrderedListAll().State(),
+			exampleocpath.Root().Model().SingleKeyAny().OrderedListMap().State(),
 			"",
 			testutil.GNMIPath(t, "/model/a/single-key[key=*]/ordered-lists"),
 			[]*ygnmi.Value[*exampleoc.Model_SingleKey_OrderedList_OrderedMap]{
@@ -2826,7 +2826,7 @@ func TestUpdate(t *testing.T) {
 				t.Fatal(err)
 			}
 			ol.SetValue(44)
-			return ygnmi.Update(context.Background(), c, exampleocpath.Root().Model().SingleKey("foo").OrderedListAll().Config(), om)
+			return ygnmi.Update(context.Background(), c, exampleocpath.Root().Model().SingleKey("foo").OrderedListMap().Config(), om)
 		},
 		wantRequest: &gpb.SetRequest{
 			Prefix: &gpb.Path{
@@ -3120,7 +3120,7 @@ func TestReplace(t *testing.T) {
 				t.Fatal(err)
 			}
 			ol.SetValue(44)
-			return ygnmi.Replace(context.Background(), c, exampleocpath.Root().Model().SingleKey("foo").OrderedListAll().Config(), om)
+			return ygnmi.Replace(context.Background(), c, exampleocpath.Root().Model().SingleKey("foo").OrderedListMap().Config(), om)
 		},
 		wantRequest: &gpb.SetRequest{
 			Prefix: &gpb.Path{
@@ -3237,7 +3237,7 @@ func TestDelete(t *testing.T) {
 	}, {
 		desc: "YANG ordered list",
 		op: func(c *ygnmi.Client) (*ygnmi.Result, error) {
-			return ygnmi.Delete(context.Background(), c, exampleocpath.Root().Model().SingleKey("foo").OrderedListAll().Config())
+			return ygnmi.Delete(context.Background(), c, exampleocpath.Root().Model().SingleKey("foo").OrderedListMap().Config())
 		},
 		wantRequest: &gpb.SetRequest{
 			Prefix: &gpb.Path{


### PR DESCRIPTION
See comment I sent offline for more details. This would mean that for all lists in compressed generation, that this method would be generated. For atomic lists the path simply ends here.

The benefits are (for compressed generation only),
1. Allows querying just the whole list without using batch.
2. Allows replacing on the whole list rather than one element at a time.