### PR TITLE
generate_ordered_map -> generate_atomic_lists

### DIFF
--- a/internal/exampleocunordered/gen.sh
+++ b/internal/exampleocunordered/gen.sh
@@ -20,7 +20,7 @@ cd "$(dirname "$0")"
 go run ../../app/ygnmi generator \
   --trim_module_prefix=openconfig \
   --base_package_path=github.com/openconfig/ygnmi/internal/exampleocunordered \
-  --generate_ordered_maps=false \
+  --generate_atomic_lists=false \
   ../../pathgen/testdata/yang/openconfig-simple.yang \
   ../../pathgen/testdata/yang/openconfig-withlistval.yang \
   ../../pathgen/testdata/yang/openconfig-nested.yang

--- a/internal/exampleocunordered/withlistval/withlistval-0.go
+++ b/internal/exampleocunordered/withlistval/withlistval-0.go
@@ -128,38 +128,6 @@ func (n *ModelPathAny) MultiKey(Key1 uint32, Key2 uint64) *Model_MultiKeyPathAny
 	}
 }
 
-// MultiKeyMap (list):
-//
-//	Defining module:      "openconfig-withlistval"
-//	Instantiating module: "openconfig-withlistval"
-//	Path from parent:     "b/multi-key"
-//	Path from root:       "/model/b/multi-key"
-func (n *ModelPath) MultiKeyMap() *Model_MultiKeyPathMap {
-	return &Model_MultiKeyPathMap{
-		NodePath: ygnmi.NewNodePath(
-			[]string{"b"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
-
-// MultiKeyMap (list):
-//
-//	Defining module:      "openconfig-withlistval"
-//	Instantiating module: "openconfig-withlistval"
-//	Path from parent:     "b/multi-key"
-//	Path from root:       "/model/b/multi-key"
-func (n *ModelPathAny) MultiKeyMap() *Model_MultiKeyPathMapAny {
-	return &Model_MultiKeyPathMapAny{
-		NodePath: ygnmi.NewNodePath(
-			[]string{"b"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
-
 // NoKeyAny (list):
 //
 //	Defining module:      "openconfig-withlistval"
@@ -255,38 +223,6 @@ func (n *ModelPathAny) SingleKey(Key string) *Model_SingleKeyPathAny {
 		NodePath: ygnmi.NewNodePath(
 			[]string{"a", "single-key"},
 			map[string]interface{}{"key": Key},
-			n,
-		),
-	}
-}
-
-// SingleKeyMap (list):
-//
-//	Defining module:      "openconfig-withlistval"
-//	Instantiating module: "openconfig-withlistval"
-//	Path from parent:     "a/single-key"
-//	Path from root:       "/model/a/single-key"
-func (n *ModelPath) SingleKeyMap() *Model_SingleKeyPathMap {
-	return &Model_SingleKeyPathMap{
-		NodePath: ygnmi.NewNodePath(
-			[]string{"a"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
-
-// SingleKeyMap (list):
-//
-//	Defining module:      "openconfig-withlistval"
-//	Instantiating module: "openconfig-withlistval"
-//	Path from parent:     "a/single-key"
-//	Path from root:       "/model/a/single-key"
-func (n *ModelPathAny) SingleKeyMap() *Model_SingleKeyPathMapAny {
-	return &Model_SingleKeyPathMapAny{
-		NodePath: ygnmi.NewNodePath(
-			[]string{"a"},
-			map[string]interface{}{},
 			n,
 		),
 	}
@@ -881,116 +817,6 @@ func (n *Model_MultiKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_MultiKey]
 			}
 		},
 		nil,
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *Model_MultiKeyPathMap) State() ygnmi.SingletonQuery[map[oc.Model_MultiKey_Key]*oc.Model_MultiKey] {
-	return ygnmi.NewSingletonQuery[map[oc.Model_MultiKey_Key]*oc.Model_MultiKey](
-		"Model",
-		true,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[oc.Model_MultiKey_Key]*oc.Model_MultiKey, bool) {
-			ret := gs.(*oc.Model).MultiKey
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model) },
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-		nil,
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:b"},
-			PostRelPath: []string{"openconfig-withlistval:multi-key"},
-		},
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *Model_MultiKeyPathMapAny) State() ygnmi.WildcardQuery[map[oc.Model_MultiKey_Key]*oc.Model_MultiKey] {
-	return ygnmi.NewWildcardQuery[map[oc.Model_MultiKey_Key]*oc.Model_MultiKey](
-		"Model",
-		true,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[oc.Model_MultiKey_Key]*oc.Model_MultiKey, bool) {
-			ret := gs.(*oc.Model).MultiKey
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model) },
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:b"},
-			PostRelPath: []string{"openconfig-withlistval:multi-key"},
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *Model_MultiKeyPathMap) Config() ygnmi.ConfigQuery[map[oc.Model_MultiKey_Key]*oc.Model_MultiKey] {
-	return ygnmi.NewConfigQuery[map[oc.Model_MultiKey_Key]*oc.Model_MultiKey](
-		"Model",
-		false,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[oc.Model_MultiKey_Key]*oc.Model_MultiKey, bool) {
-			ret := gs.(*oc.Model).MultiKey
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model) },
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-		nil,
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:b"},
-			PostRelPath: []string{"openconfig-withlistval:multi-key"},
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *Model_MultiKeyPathMapAny) Config() ygnmi.WildcardQuery[map[oc.Model_MultiKey_Key]*oc.Model_MultiKey] {
-	return ygnmi.NewWildcardQuery[map[oc.Model_MultiKey_Key]*oc.Model_MultiKey](
-		"Model",
-		false,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[oc.Model_MultiKey_Key]*oc.Model_MultiKey, bool) {
-			ret := gs.(*oc.Model).MultiKey
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model) },
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:b"},
-			PostRelPath: []string{"openconfig-withlistval:multi-key"},
-		},
 	)
 }
 
@@ -1788,65 +1614,69 @@ func (n *Model_SingleKeyPathAny) OrderedList(Key string) *Model_SingleKey_Ordere
 	}
 }
 
-// OrderedListMap (list):
-//
-//	Defining module:      "openconfig-withlistval"
-//	Instantiating module: "openconfig-withlistval"
-//	Path from parent:     "ordered-lists/ordered-list"
-//	Path from root:       "/model/a/single-key/ordered-lists/ordered-list"
-func (n *Model_SingleKeyPath) OrderedListMap() *Model_SingleKey_OrderedListPathMap {
-	return &Model_SingleKey_OrderedListPathMap{
-		NodePath: ygnmi.NewNodePath(
-			[]string{"ordered-lists"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
-
-// OrderedListMap (list):
-//
-//	Defining module:      "openconfig-withlistval"
-//	Instantiating module: "openconfig-withlistval"
-//	Path from parent:     "ordered-lists/ordered-list"
-//	Path from root:       "/model/a/single-key/ordered-lists/ordered-list"
-func (n *Model_SingleKeyPathAny) OrderedListMap() *Model_SingleKey_OrderedListPathMapAny {
-	return &Model_SingleKey_OrderedListPathMapAny{
-		NodePath: ygnmi.NewNodePath(
-			[]string{"ordered-lists"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
-
-// SingleKeyMap (list):
+// SingleKeyAny (list):
 //
 //	Defining module:      "openconfig-withlistval"
 //	Instantiating module: "openconfig-withlistval"
 //	Path from parent:     "inner-a/single-key"
 //	Path from root:       "/model/a/single-key/inner-a/single-key"
-func (n *Model_SingleKeyPath) SingleKeyMap() *Model_SingleKey_SingleKeyPathMap {
-	return &Model_SingleKey_SingleKeyPathMap{
+func (n *Model_SingleKeyPath) SingleKeyAny() *Model_SingleKey_SingleKeyPathAny {
+	return &Model_SingleKey_SingleKeyPathAny{
 		NodePath: ygnmi.NewNodePath(
-			[]string{"inner-a"},
-			map[string]interface{}{},
+			[]string{"inner-a", "single-key"},
+			map[string]interface{}{"key": "*"},
 			n,
 		),
 	}
 }
 
-// SingleKeyMap (list):
+// SingleKeyAny (list):
 //
 //	Defining module:      "openconfig-withlistval"
 //	Instantiating module: "openconfig-withlistval"
 //	Path from parent:     "inner-a/single-key"
 //	Path from root:       "/model/a/single-key/inner-a/single-key"
-func (n *Model_SingleKeyPathAny) SingleKeyMap() *Model_SingleKey_SingleKeyPathMapAny {
-	return &Model_SingleKey_SingleKeyPathMapAny{
+func (n *Model_SingleKeyPathAny) SingleKeyAny() *Model_SingleKey_SingleKeyPathAny {
+	return &Model_SingleKey_SingleKeyPathAny{
 		NodePath: ygnmi.NewNodePath(
-			[]string{"inner-a"},
-			map[string]interface{}{},
+			[]string{"inner-a", "single-key"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
+// SingleKey (list):
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "inner-a/single-key"
+//	Path from root:       "/model/a/single-key/inner-a/single-key"
+//
+//	Key: string
+func (n *Model_SingleKeyPath) SingleKey(Key string) *Model_SingleKey_SingleKeyPath {
+	return &Model_SingleKey_SingleKeyPath{
+		NodePath: ygnmi.NewNodePath(
+			[]string{"inner-a", "single-key"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+
+// SingleKey (list):
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "inner-a/single-key"
+//	Path from root:       "/model/a/single-key/inner-a/single-key"
+//
+//	Key: string
+func (n *Model_SingleKeyPathAny) SingleKey(Key string) *Model_SingleKey_SingleKeyPathAny {
+	return &Model_SingleKey_SingleKeyPathAny{
+		NodePath: ygnmi.NewNodePath(
+			[]string{"inner-a", "single-key"},
+			map[string]interface{}{"key": Key},
 			n,
 		),
 	}
@@ -1969,116 +1799,6 @@ func (n *Model_SingleKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_SingleKe
 			}
 		},
 		nil,
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKeyPathMap) State() ygnmi.SingletonQuery[map[string]*oc.Model_SingleKey] {
-	return ygnmi.NewSingletonQuery[map[string]*oc.Model_SingleKey](
-		"Model",
-		true,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[string]*oc.Model_SingleKey, bool) {
-			ret := gs.(*oc.Model).SingleKey
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model) },
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-		nil,
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:a"},
-			PostRelPath: []string{"openconfig-withlistval:single-key"},
-		},
-	)
-}
-
-// State returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKeyPathMapAny) State() ygnmi.WildcardQuery[map[string]*oc.Model_SingleKey] {
-	return ygnmi.NewWildcardQuery[map[string]*oc.Model_SingleKey](
-		"Model",
-		true,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[string]*oc.Model_SingleKey, bool) {
-			ret := gs.(*oc.Model).SingleKey
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model) },
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:a"},
-			PostRelPath: []string{"openconfig-withlistval:single-key"},
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKeyPathMap) Config() ygnmi.ConfigQuery[map[string]*oc.Model_SingleKey] {
-	return ygnmi.NewConfigQuery[map[string]*oc.Model_SingleKey](
-		"Model",
-		false,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[string]*oc.Model_SingleKey, bool) {
-			ret := gs.(*oc.Model).SingleKey
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model) },
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-		nil,
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:a"},
-			PostRelPath: []string{"openconfig-withlistval:single-key"},
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKeyPathMapAny) Config() ygnmi.WildcardQuery[map[string]*oc.Model_SingleKey] {
-	return ygnmi.NewWildcardQuery[map[string]*oc.Model_SingleKey](
-		"Model",
-		false,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[string]*oc.Model_SingleKey, bool) {
-			ret := gs.(*oc.Model).SingleKey
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model) },
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:a"},
-			PostRelPath: []string{"openconfig-withlistval:single-key"},
-		},
 	)
 }
 
@@ -2580,19 +2300,44 @@ func (n *Model_SingleKey_OrderedListPathAny) Config() ygnmi.WildcardQuery[*oc.Mo
 	)
 }
 
+// Model_SingleKey_SingleKey_KeyPath represents the /openconfig-withlistval/model/a/single-key/inner-a/single-key/state/key YANG schema element.
+type Model_SingleKey_SingleKey_KeyPath struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
+// Model_SingleKey_SingleKey_KeyPathAny represents the wildcard version of the /openconfig-withlistval/model/a/single-key/inner-a/single-key/state/key YANG schema element.
+type Model_SingleKey_SingleKey_KeyPathAny struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
 // State returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKey_OrderedListPathMap) State() ygnmi.SingletonQuery[map[string]*oc.Model_SingleKey_OrderedList] {
-	return ygnmi.NewSingletonQuery[map[string]*oc.Model_SingleKey_OrderedList](
-		"Model_SingleKey",
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "state/key"
+//	Path from root:       "/model/a/single-key/inner-a/single-key/state/key"
+func (n *Model_SingleKey_SingleKey_KeyPath) State() ygnmi.SingletonQuery[string] {
+	return ygnmi.NewSingletonQuery[string](
+		"Model_SingleKey_SingleKey",
 		true,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[string]*oc.Model_SingleKey_OrderedList, bool) {
-			ret := gs.(*oc.Model_SingleKey).OrderedList
-			return ret, ret != nil
+		true,
+		true,
+		ygnmi.NewNodePath(
+			[]string{"state", "key"},
+			nil,
+			n.parent,
+		),
+		func(gs ygot.ValidatedGoStruct) (string, bool) {
+			ret := gs.(*oc.Model_SingleKey_SingleKey).Key
+			if ret == nil {
+				var zero string
+				return zero, false
+			}
+			return *ret, true
 		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey) },
+		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey_SingleKey) },
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -2601,53 +2346,36 @@ func (n *Model_SingleKey_OrderedListPathMap) State() ygnmi.SingletonQuery[map[st
 			}
 		},
 		nil,
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:ordered-lists"},
-			PostRelPath: []string{"openconfig-withlistval:ordered-list"},
-		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKey_OrderedListPathMapAny) State() ygnmi.WildcardQuery[map[string]*oc.Model_SingleKey_OrderedList] {
-	return ygnmi.NewWildcardQuery[map[string]*oc.Model_SingleKey_OrderedList](
-		"Model_SingleKey",
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "state/key"
+//	Path from root:       "/model/a/single-key/inner-a/single-key/state/key"
+func (n *Model_SingleKey_SingleKey_KeyPathAny) State() ygnmi.WildcardQuery[string] {
+	return ygnmi.NewWildcardQuery[string](
+		"Model_SingleKey_SingleKey",
 		true,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[string]*oc.Model_SingleKey_OrderedList, bool) {
-			ret := gs.(*oc.Model_SingleKey).OrderedList
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey) },
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
+		true,
+		true,
+		ygnmi.NewNodePath(
+			[]string{"state", "key"},
+			nil,
+			n.parent,
+		),
+		func(gs ygot.ValidatedGoStruct) (string, bool) {
+			ret := gs.(*oc.Model_SingleKey_SingleKey).Key
+			if ret == nil {
+				var zero string
+				return zero, false
 			}
+			return *ret, true
 		},
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:ordered-lists"},
-			PostRelPath: []string{"openconfig-withlistval:ordered-list"},
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKey_OrderedListPathMap) Config() ygnmi.ConfigQuery[map[string]*oc.Model_SingleKey_OrderedList] {
-	return ygnmi.NewConfigQuery[map[string]*oc.Model_SingleKey_OrderedList](
-		"Model_SingleKey",
-		false,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[string]*oc.Model_SingleKey_OrderedList, bool) {
-			ret := gs.(*oc.Model_SingleKey).OrderedList
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey) },
+		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey_SingleKey) },
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -2656,26 +2384,35 @@ func (n *Model_SingleKey_OrderedListPathMap) Config() ygnmi.ConfigQuery[map[stri
 			}
 		},
 		nil,
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:ordered-lists"},
-			PostRelPath: []string{"openconfig-withlistval:ordered-list"},
-		},
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKey_OrderedListPathMapAny) Config() ygnmi.WildcardQuery[map[string]*oc.Model_SingleKey_OrderedList] {
-	return ygnmi.NewWildcardQuery[map[string]*oc.Model_SingleKey_OrderedList](
-		"Model_SingleKey",
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "config/key"
+//	Path from root:       "/model/a/single-key/inner-a/single-key/config/key"
+func (n *Model_SingleKey_SingleKey_KeyPath) Config() ygnmi.ConfigQuery[string] {
+	return ygnmi.NewConfigQuery[string](
+		"Model_SingleKey_SingleKey",
 		false,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[string]*oc.Model_SingleKey_OrderedList, bool) {
-			ret := gs.(*oc.Model_SingleKey).OrderedList
-			return ret, ret != nil
+		true,
+		true,
+		ygnmi.NewNodePath(
+			[]string{"config", "key"},
+			nil,
+			n.parent,
+		),
+		func(gs ygot.ValidatedGoStruct) (string, bool) {
+			ret := gs.(*oc.Model_SingleKey_SingleKey).Key
+			if ret == nil {
+				var zero string
+				return zero, false
+			}
+			return *ret, true
 		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey) },
+		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey_SingleKey) },
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -2683,10 +2420,207 @@ func (n *Model_SingleKey_OrderedListPathMapAny) Config() ygnmi.WildcardQuery[map
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:ordered-lists"},
-			PostRelPath: []string{"openconfig-withlistval:ordered-list"},
+		nil,
+		nil,
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "config/key"
+//	Path from root:       "/model/a/single-key/inner-a/single-key/config/key"
+func (n *Model_SingleKey_SingleKey_KeyPathAny) Config() ygnmi.WildcardQuery[string] {
+	return ygnmi.NewWildcardQuery[string](
+		"Model_SingleKey_SingleKey",
+		false,
+		true,
+		true,
+		ygnmi.NewNodePath(
+			[]string{"config", "key"},
+			nil,
+			n.parent,
+		),
+		func(gs ygot.ValidatedGoStruct) (string, bool) {
+			ret := gs.(*oc.Model_SingleKey_SingleKey).Key
+			if ret == nil {
+				var zero string
+				return zero, false
+			}
+			return *ret, true
 		},
+		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey_SingleKey) },
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+		nil,
+	)
+}
+
+// Model_SingleKey_SingleKey_ValuePath represents the /openconfig-withlistval/model/a/single-key/inner-a/single-key/state/value YANG schema element.
+type Model_SingleKey_SingleKey_ValuePath struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
+// Model_SingleKey_SingleKey_ValuePathAny represents the wildcard version of the /openconfig-withlistval/model/a/single-key/inner-a/single-key/state/value YANG schema element.
+type Model_SingleKey_SingleKey_ValuePathAny struct {
+	*ygnmi.NodePath
+	parent ygnmi.PathStruct
+}
+
+// State returns a Query that can be used in gNMI operations.
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "state/value"
+//	Path from root:       "/model/a/single-key/inner-a/single-key/state/value"
+func (n *Model_SingleKey_SingleKey_ValuePath) State() ygnmi.SingletonQuery[int64] {
+	return ygnmi.NewSingletonQuery[int64](
+		"Model_SingleKey_SingleKey",
+		true,
+		true,
+		true,
+		ygnmi.NewNodePath(
+			[]string{"state", "value"},
+			nil,
+			n.parent,
+		),
+		func(gs ygot.ValidatedGoStruct) (int64, bool) {
+			ret := gs.(*oc.Model_SingleKey_SingleKey).Value
+			if ret == nil {
+				var zero int64
+				return zero, false
+			}
+			return *ret, true
+		},
+		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey_SingleKey) },
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+		nil,
+		nil,
+	)
+}
+
+// State returns a Query that can be used in gNMI operations.
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "state/value"
+//	Path from root:       "/model/a/single-key/inner-a/single-key/state/value"
+func (n *Model_SingleKey_SingleKey_ValuePathAny) State() ygnmi.WildcardQuery[int64] {
+	return ygnmi.NewWildcardQuery[int64](
+		"Model_SingleKey_SingleKey",
+		true,
+		true,
+		true,
+		ygnmi.NewNodePath(
+			[]string{"state", "value"},
+			nil,
+			n.parent,
+		),
+		func(gs ygot.ValidatedGoStruct) (int64, bool) {
+			ret := gs.(*oc.Model_SingleKey_SingleKey).Value
+			if ret == nil {
+				var zero int64
+				return zero, false
+			}
+			return *ret, true
+		},
+		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey_SingleKey) },
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+		nil,
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "config/value"
+//	Path from root:       "/model/a/single-key/inner-a/single-key/config/value"
+func (n *Model_SingleKey_SingleKey_ValuePath) Config() ygnmi.ConfigQuery[int64] {
+	return ygnmi.NewConfigQuery[int64](
+		"Model_SingleKey_SingleKey",
+		false,
+		true,
+		true,
+		ygnmi.NewNodePath(
+			[]string{"config", "value"},
+			nil,
+			n.parent,
+		),
+		func(gs ygot.ValidatedGoStruct) (int64, bool) {
+			ret := gs.(*oc.Model_SingleKey_SingleKey).Value
+			if ret == nil {
+				var zero int64
+				return zero, false
+			}
+			return *ret, true
+		},
+		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey_SingleKey) },
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+		nil,
+		nil,
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "config/value"
+//	Path from root:       "/model/a/single-key/inner-a/single-key/config/value"
+func (n *Model_SingleKey_SingleKey_ValuePathAny) Config() ygnmi.WildcardQuery[int64] {
+	return ygnmi.NewWildcardQuery[int64](
+		"Model_SingleKey_SingleKey",
+		false,
+		true,
+		true,
+		ygnmi.NewNodePath(
+			[]string{"config", "value"},
+			nil,
+			n.parent,
+		),
+		func(gs ygot.ValidatedGoStruct) (int64, bool) {
+			ret := gs.(*oc.Model_SingleKey_SingleKey).Value
+			if ret == nil {
+				var zero int64
+				return zero, false
+			}
+			return *ret, true
+		},
+		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey_SingleKey) },
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+		nil,
 	)
 }
 
@@ -2710,19 +2644,84 @@ type Model_SingleKey_SingleKeyPathMapAny struct {
 	*ygnmi.NodePath
 }
 
+// Key (leaf):
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "*/key"
+//	Path from root:       "/model/a/single-key/inner-a/single-key/*/key"
+func (n *Model_SingleKey_SingleKeyPath) Key() *Model_SingleKey_SingleKey_KeyPath {
+	return &Model_SingleKey_SingleKey_KeyPath{
+		NodePath: ygnmi.NewNodePath(
+			[]string{"*", "key"},
+			map[string]interface{}{},
+			n,
+		),
+		parent: n,
+	}
+}
+
+// Key (leaf):
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "*/key"
+//	Path from root:       "/model/a/single-key/inner-a/single-key/*/key"
+func (n *Model_SingleKey_SingleKeyPathAny) Key() *Model_SingleKey_SingleKey_KeyPathAny {
+	return &Model_SingleKey_SingleKey_KeyPathAny{
+		NodePath: ygnmi.NewNodePath(
+			[]string{"*", "key"},
+			map[string]interface{}{},
+			n,
+		),
+		parent: n,
+	}
+}
+
+// Value (leaf):
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "*/value"
+//	Path from root:       "/model/a/single-key/inner-a/single-key/*/value"
+func (n *Model_SingleKey_SingleKeyPath) Value() *Model_SingleKey_SingleKey_ValuePath {
+	return &Model_SingleKey_SingleKey_ValuePath{
+		NodePath: ygnmi.NewNodePath(
+			[]string{"*", "value"},
+			map[string]interface{}{},
+			n,
+		),
+		parent: n,
+	}
+}
+
+// Value (leaf):
+//
+//	Defining module:      "openconfig-withlistval"
+//	Instantiating module: "openconfig-withlistval"
+//	Path from parent:     "*/value"
+//	Path from root:       "/model/a/single-key/inner-a/single-key/*/value"
+func (n *Model_SingleKey_SingleKeyPathAny) Value() *Model_SingleKey_SingleKey_ValuePathAny {
+	return &Model_SingleKey_SingleKey_ValuePathAny{
+		NodePath: ygnmi.NewNodePath(
+			[]string{"*", "value"},
+			map[string]interface{}{},
+			n,
+		),
+		parent: n,
+	}
+}
+
 // State returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKey_SingleKeyPathMap) State() ygnmi.SingletonQuery[map[string]*oc.Model_SingleKey_SingleKey] {
-	return ygnmi.NewSingletonQuery[map[string]*oc.Model_SingleKey_SingleKey](
-		"Model_SingleKey",
+func (n *Model_SingleKey_SingleKeyPath) State() ygnmi.SingletonQuery[*oc.Model_SingleKey_SingleKey] {
+	return ygnmi.NewSingletonQuery[*oc.Model_SingleKey_SingleKey](
+		"Model_SingleKey_SingleKey",
 		true,
 		false,
 		false,
 		n,
-		func(gs ygot.ValidatedGoStruct) (map[string]*oc.Model_SingleKey_SingleKey, bool) {
-			ret := gs.(*oc.Model_SingleKey).SingleKey
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey) },
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -2731,53 +2730,20 @@ func (n *Model_SingleKey_SingleKeyPathMap) State() ygnmi.SingletonQuery[map[stri
 			}
 		},
 		nil,
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:inner-a"},
-			PostRelPath: []string{"openconfig-withlistval:single-key"},
-		},
+		nil,
 	)
 }
 
 // State returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKey_SingleKeyPathMapAny) State() ygnmi.WildcardQuery[map[string]*oc.Model_SingleKey_SingleKey] {
-	return ygnmi.NewWildcardQuery[map[string]*oc.Model_SingleKey_SingleKey](
-		"Model_SingleKey",
+func (n *Model_SingleKey_SingleKeyPathAny) State() ygnmi.WildcardQuery[*oc.Model_SingleKey_SingleKey] {
+	return ygnmi.NewWildcardQuery[*oc.Model_SingleKey_SingleKey](
+		"Model_SingleKey_SingleKey",
 		true,
 		false,
 		false,
 		n,
-		func(gs ygot.ValidatedGoStruct) (map[string]*oc.Model_SingleKey_SingleKey, bool) {
-			ret := gs.(*oc.Model_SingleKey).SingleKey
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey) },
-		func() *ytypes.Schema {
-			return &ytypes.Schema{
-				Root:       &oc.Root{},
-				SchemaTree: oc.SchemaTree,
-				Unmarshal:  oc.Unmarshal,
-			}
-		},
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:inner-a"},
-			PostRelPath: []string{"openconfig-withlistval:single-key"},
-		},
-	)
-}
-
-// Config returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKey_SingleKeyPathMap) Config() ygnmi.ConfigQuery[map[string]*oc.Model_SingleKey_SingleKey] {
-	return ygnmi.NewConfigQuery[map[string]*oc.Model_SingleKey_SingleKey](
-		"Model_SingleKey",
-		false,
-		false,
-		false,
-		n,
-		func(gs ygot.ValidatedGoStruct) (map[string]*oc.Model_SingleKey_SingleKey, bool) {
-			ret := gs.(*oc.Model_SingleKey).SingleKey
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey) },
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -2786,26 +2752,19 @@ func (n *Model_SingleKey_SingleKeyPathMap) Config() ygnmi.ConfigQuery[map[string
 			}
 		},
 		nil,
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:inner-a"},
-			PostRelPath: []string{"openconfig-withlistval:single-key"},
-		},
 	)
 }
 
 // Config returns a Query that can be used in gNMI operations.
-func (n *Model_SingleKey_SingleKeyPathMapAny) Config() ygnmi.WildcardQuery[map[string]*oc.Model_SingleKey_SingleKey] {
-	return ygnmi.NewWildcardQuery[map[string]*oc.Model_SingleKey_SingleKey](
-		"Model_SingleKey",
+func (n *Model_SingleKey_SingleKeyPath) Config() ygnmi.ConfigQuery[*oc.Model_SingleKey_SingleKey] {
+	return ygnmi.NewConfigQuery[*oc.Model_SingleKey_SingleKey](
+		"Model_SingleKey_SingleKey",
 		false,
 		false,
 		false,
 		n,
-		func(gs ygot.ValidatedGoStruct) (map[string]*oc.Model_SingleKey_SingleKey, bool) {
-			ret := gs.(*oc.Model_SingleKey).SingleKey
-			return ret, ret != nil
-		},
-		func() ygot.ValidatedGoStruct { return new(oc.Model_SingleKey) },
+		nil,
+		nil,
 		func() *ytypes.Schema {
 			return &ytypes.Schema{
 				Root:       &oc.Root{},
@@ -2813,9 +2772,28 @@ func (n *Model_SingleKey_SingleKeyPathMapAny) Config() ygnmi.WildcardQuery[map[s
 				Unmarshal:  oc.Unmarshal,
 			}
 		},
-		&ygnmi.CompressionInfo{
-			PreRelPath:  []string{"openconfig-withlistval:inner-a"},
-			PostRelPath: []string{"openconfig-withlistval:single-key"},
+		nil,
+		nil,
+	)
+}
+
+// Config returns a Query that can be used in gNMI operations.
+func (n *Model_SingleKey_SingleKeyPathAny) Config() ygnmi.WildcardQuery[*oc.Model_SingleKey_SingleKey] {
+	return ygnmi.NewWildcardQuery[*oc.Model_SingleKey_SingleKey](
+		"Model_SingleKey_SingleKey",
+		false,
+		false,
+		false,
+		n,
+		nil,
+		nil,
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
 		},
+		nil,
 	)
 }

--- a/pathgen/pathgen_test.go
+++ b/pathgen/pathgen_test.go
@@ -59,10 +59,10 @@ func TestGeneratePathCode(t *testing.T) {
 		// inUseDefiningModuleForTypedefEnumNames uses the defining module name to prefix typedef enumerated types instead of the module where the typedef enumerated value is used.
 		inUseDefiningModuleForTypedefEnumNames bool
 		// inGenerateWildcardPaths determines whether wildcard paths are generated.
-		inGenerateWildcardPaths               bool
-		inSchemaStructPkgPath                 string
-		inPathStructSuffix                    string
-		inGenerateOrderedListsAsUnorderedMaps bool
+		inGenerateWildcardPaths bool
+		inSchemaStructPkgPath   string
+		inPathStructSuffix      string
+		inIgnoreAtomicLists     bool
 		// checkYANGPath says whether to check for the YANG path in the NodeDataMap.
 		checkYANGPath bool
 		// wantStructsCodeFile is the path of the generated Go code that the output of the test should be compared to.
@@ -553,7 +553,7 @@ func TestGeneratePathCode(t *testing.T) {
 				DirectoryName:         "/openconfig-orderedlist/model/ordered-lists/ordered-list",
 			}},
 	}, {
-		name:                                   "simple openconfig test with ordered list but turned off",
+		name:                                   "simple openconfig test with ordered list but atomic generation turned off",
 		inFiles:                                []string{filepath.Join(datapath, "openconfig-orderedlist.yang")},
 		inPreferOperationalState:               true,
 		inShortenEnumLeafNames:                 true,
@@ -561,7 +561,7 @@ func TestGeneratePathCode(t *testing.T) {
 		inGenerateWildcardPaths:                true,
 		inSchemaStructPkgPath:                  "",
 		inPathStructSuffix:                     "Path",
-		inGenerateOrderedListsAsUnorderedMaps:  true,
+		inIgnoreAtomicLists:                    true,
 		checkYANGPath:                          true,
 		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-orderedlist-unordered.path-txt"),
 		wantNodeDataMap: NodeDataMap{
@@ -581,19 +581,6 @@ func TestGeneratePathCode(t *testing.T) {
 				YANGPath:              "/openconfig-orderedlist/model",
 				GoPathPackageName:     "ocstructs",
 				DirectoryName:         "/openconfig-orderedlist/model",
-			},
-			"Model_OrderedListPathMap": {
-				GoTypeName:            "map[string]*Model_OrderedList",
-				LocalGoTypeName:       "map[string]*Model_OrderedList",
-				GoFieldName:           "OrderedList",
-				SubsumingGoStructName: "Model",
-				YANGPath:              "/openconfig-orderedlist/model/ordered-lists/ordered-list",
-				GoPathPackageName:     "ocstructs",
-				DirectoryName:         "/openconfig-orderedlist/model/ordered-lists/ordered-list",
-				CompressInfo: &CompressionInfo{
-					PreRelPathList:  `"openconfig-orderedlist:ordered-lists"`,
-					PostRelPathList: `"openconfig-orderedlist:ordered-list"`,
-				},
 			},
 			"Model_OrderedListPath": {
 				GoTypeName:            "*Model_OrderedList",
@@ -1281,7 +1268,7 @@ func TestGeneratePathCode(t *testing.T) {
 				cg.UseDefiningModuleForTypedefEnumNames = tt.inUseDefiningModuleForTypedefEnumNames
 				cg.GenerateWildcardPaths = tt.inGenerateWildcardPaths
 				cg.PackageName = "ocstructs"
-				cg.GenerateOrderedListsAsUnorderedMaps = tt.inGenerateOrderedListsAsUnorderedMaps
+				cg.IgnoreAtomicLists = tt.inIgnoreAtomicLists
 
 				gotCode, gotNodeDataMap, err := cg.GeneratePathCode(tt.inFiles, tt.inIncludePaths)
 				if err != nil && !tt.wantErr {

--- a/pathgen/testdata/structs/openconfig-orderedlist-unordered.path-txt
+++ b/pathgen/testdata/structs/openconfig-orderedlist-unordered.path-txt
@@ -116,36 +116,6 @@ func (n *ModelPathAny) OrderedList(Key string) *Model_OrderedListPathAny {
 	}
 }
 
-// OrderedListMap (list): 
-// 	Defining module:      "openconfig-orderedlist"
-// 	Instantiating module: "openconfig-orderedlist"
-// 	Path from parent:     "ordered-lists/ordered-list"
-// 	Path from root:       "/model/ordered-lists/ordered-list"
-func (n *ModelPath) OrderedListMap() *Model_OrderedListPathMap {
-	return &Model_OrderedListPathMap{
-		NodePath: ygnmi.NewNodePath(
-			[]string{"ordered-lists"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
-
-// OrderedListMap (list): 
-// 	Defining module:      "openconfig-orderedlist"
-// 	Instantiating module: "openconfig-orderedlist"
-// 	Path from parent:     "ordered-lists/ordered-list"
-// 	Path from root:       "/model/ordered-lists/ordered-list"
-func (n *ModelPathAny) OrderedListMap() *Model_OrderedListPathMapAny {
-	return &Model_OrderedListPathMapAny{
-		NodePath: ygnmi.NewNodePath(
-			[]string{"ordered-lists"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
-
 // Model_OrderedList_KeyPath represents the /openconfig-orderedlist/model/ordered-lists/ordered-list/state/key YANG schema element.
 type Model_OrderedList_KeyPath struct {
 	*ygnmi.NodePath

--- a/ygnmi/ygnmi_test.go
+++ b/ygnmi/ygnmi_test.go
@@ -686,52 +686,6 @@ func TestLookup(t *testing.T) {
 
 func TestUnorderedOrderedMap(t *testing.T) {
 	fakeGNMI, c := newClient(t)
-	t.Run("success unordered ordered map", func(t *testing.T) {
-		fakeGNMI.Stub().Notification(&gpb.Notification{
-			Timestamp: 100,
-			Prefix:    testutil.GNMIPath(t, "/model/a/single-key[key=foo]/ordered-lists"),
-			Update: []*gpb.Update{{
-				Path: testutil.GNMIPath(t, `ordered-list[key=foo]/config/key`),
-				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "foo"}},
-			}, {
-				Path: testutil.GNMIPath(t, `ordered-list[key=foo]/key`),
-				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "foo"}},
-			}, {
-				Path: testutil.GNMIPath(t, `ordered-list[key=foo]/config/value`),
-				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_IntVal{IntVal: 42}},
-			}, {
-				Path: testutil.GNMIPath(t, `ordered-list[key=bar]/config/key`),
-				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "bar"}},
-			}, {
-				Path: testutil.GNMIPath(t, `ordered-list[key=bar]/key`),
-				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "bar"}},
-			}, {
-				Path: testutil.GNMIPath(t, `ordered-list[key=bar]/config/value`),
-				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_IntVal{IntVal: 43}},
-			}, {
-				Path: testutil.GNMIPath(t, `ordered-list[key=baz]/config/key`),
-				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "baz"}},
-			}, {
-				Path: testutil.GNMIPath(t, `ordered-list[key=baz]/key`),
-				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "baz"}},
-			}, {
-				Path: testutil.GNMIPath(t, `ordered-list[key=baz]/config/value`),
-				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_IntVal{IntVal: 44}},
-			}},
-		}).Sync()
-
-		lookupCheckFn(
-			t, fakeGNMI, c,
-			ygnmi.SingletonQuery[map[string]*exampleocunordered.Model_SingleKey_OrderedList](exampleocunorderedpath.Root().Model().SingleKey("foo").OrderedListMap().Config()),
-			"",
-			testutil.GNMIPath(t, "/model/a/single-key[key=foo]/ordered-lists"),
-			(&ygnmi.Value[map[string]*exampleocunordered.Model_SingleKey_OrderedList]{
-				Path:      testutil.GNMIPath(t, "/model/a/single-key[key=foo]/ordered-lists"),
-				Timestamp: time.Unix(0, 100),
-			}).SetVal(getSampleOrderedMapUnordered(t)),
-		)
-	})
-
 	t.Run("success unordered ordered map leaf", func(t *testing.T) {
 		fakeGNMI.Stub().Notification(&gpb.Notification{
 			Timestamp: 100,


### PR DESCRIPTION
There is downstream dependent code that ignores atomicity of lists.

Making this flag more broad so that those downstream code can also adopt newer ygnmi without having to change themselves yet.