### PR TITLE
Add support for a context in `Await`.

### DIFF
--- a/ygnmi/ygnmi.go
+++ b/ygnmi/ygnmi.go
@@ -327,7 +327,7 @@ func Watch[T any](ctx context.Context, c *Client, q SingletonQuery[T], pred func
 		for {
 			select {
 			case <-ctx.Done():
-				w.errCh <- nil
+				w.errCh <- ctx.Err()
 				return
 			case data := <-dataCh:
 				val, err := unmarshalAndExtract[T](data, q, gs, resolvedOpts)
@@ -483,7 +483,7 @@ func WatchAll[T any](ctx context.Context, c *Client, q WildcardQuery[T], pred fu
 		for {
 			select {
 			case <-ctx.Done():
-				w.errCh <- nil
+				w.errCh <- ctx.Err()
 				return
 			case data := <-dataCh:
 				datapointGroups, sortedPrefixes, err := bundleDatapoints(data, len(path.Elem))

--- a/ygnmi/ygnmi.go
+++ b/ygnmi/ygnmi.go
@@ -305,7 +305,7 @@ func (w *Watcher[T]) Await() (*Value[T], error) {
 
 // AwaitWithContext waits for the watch to finish in the same way as Await, but will
 // return immediately if the context supplied is completed.
-func (w *Watcher[T]) AwaitWithContext() (*Value[T], error) {
+func (w *Watcher[T]) AwaitWithContext(ctx context.Context) (*Value[T], error) {
 	select {
 	case err, ok := <-w.errCh:
 		if !ok {


### PR DESCRIPTION
```
  * (M) ygnmi/ygnmi.go
   - This change adds support for `Await` to take a context.Context
     that the caller can cancel. This allows the `Await` to be cancelled
     even if `pred` always returns `Continue` (required in long-lived
     subscriptions where we are actually not really ever going to exit).
   - Listen to `ctx.Done` in Watch and WatchAll to ensure that we return
     when the context is done even if we didn't get a datapoint.
```

Happy to discuss the preferred way of testing this -- it seemed like there might be a lot of duplication.

I chose to prefer not to change the function signature of `Await` (even though this would be easier :-)) for backwards compatibility.
