### PR TITLE
Prevent leaking goroutines in `receiveStream`.

### DIFF
--- a/ygnmi/gnmi.go
+++ b/ygnmi/gnmi.go
@@ -255,12 +255,9 @@ func receiveAll(sub gpb.GNMI_SubscribeClient, deletesExpected bool) (data []*Dat
 // Note: this does not imply that mode is gpb.SubscriptionList_STREAM (though it usually is).
 // If the query is a leaf, each datapoint will be sent the chan individually.
 // If the query is a non-leaf, all the datapoints from a SubscriptionResponse are bundled.
-func receiveStream[T any](sub gpb.GNMI_SubscribeClient, query AnyQuery[T]) (<-chan []*DataPoint, <-chan error) {
+func receiveStream[T any](ctx context.Context, sub gpb.GNMI_SubscribeClient, query AnyQuery[T]) (<-chan []*DataPoint, <-chan error) {
 	dataCh := make(chan []*DataPoint)
-	// If the receiver of errCh stops reading the channel before we receive an error, then the write
-	// to the channel will block. Add a buffer of 1 error such that we tolerate this case and still
-	// exit the goroutine cleanly.
-	errCh := make(chan error, 1)
+	errCh := make(chan error)
 
 	go func() {
 		defer close(dataCh)
@@ -273,7 +270,10 @@ func receiveStream[T any](sub gpb.GNMI_SubscribeClient, query AnyQuery[T]) (<-ch
 		for {
 			recvData, sync, err = receive(sub, recvData, true)
 			if err != nil {
-				errCh <- fmt.Errorf("error receiving gNMI response: %w", err)
+				select {
+				case errCh <- fmt.Errorf("error receiving gNMI response: %w", err):
+				case <-ctx.Done():
+				}
 				return
 			}
 			firstSync := !hasSynced && (sync || query.isLeaf())

--- a/ygnmi/gnmi.go
+++ b/ygnmi/gnmi.go
@@ -270,6 +270,10 @@ func receiveStream[T any](ctx context.Context, sub gpb.GNMI_SubscribeClient, que
 		for {
 			recvData, sync, err = receive(sub, recvData, true)
 			if err != nil {
+				// In the case that the context is cancelled, the reader of errCh
+				// may have gone away. In order to avoid this goroutine blocking
+				// indefinitely on the channel write, allow ctx being cancelled or
+				// done to ensure that it returns.
 				select {
 				case errCh <- fmt.Errorf("error receiving gNMI response: %w", err):
 				case <-ctx.Done():

--- a/ygnmi/ygnmi.go
+++ b/ygnmi/ygnmi.go
@@ -324,7 +324,7 @@ func Watch[T any](ctx context.Context, c *Client, q SingletonQuery[T], pred func
 		return w
 	}
 
-	dataCh, errCh := receiveStream[T](sub, q)
+	dataCh, errCh := receiveStream[T](ctx, sub, q)
 	go func() {
 		// Create an intially empty GoStruct, into which all received datapoints will be unmarshalled.
 		gs := q.goStruct()
@@ -480,7 +480,7 @@ func WatchAll[T any](ctx context.Context, c *Client, q WildcardQuery[T], pred fu
 		return w
 	}
 
-	dataCh, errCh := receiveStream[T](sub, q)
+	dataCh, errCh := receiveStream[T](ctx, sub, q)
 	go func() {
 		// Create a map intially empty GoStruct, into which all received datapoints will be unmarshalled based on their path prefixes.
 		structs := map[string]ygot.ValidatedGoStruct{}


### PR DESCRIPTION
```
* (M) ygnmi/gnmi.go
   - In the case that the transport closes the caller of `receiveStream`
     may have already gone away and stopped reading errCh. In this case
     the `receiveStream` goroutine will be leaked and never exit. This
     change adds a buffer to ensure that we can at least process if
     there was another error and hence return.
```

In the handling of `dataCh` and `errCh` in `WatchAll`, if the context provided
to `WatchAll` is cancelled then the receiving goroutine will exit
([code](https://github.com/openconfig/ygnmi/blob/428d94dd66c7cd72be53e3a9d4f9753cc612d878/ygnmi/ygnmi.go#L489-L491)). In this case, there will be no reader of `errCh` and hence writing to it will
block [here](https://github.com/openconfig/ygnmi/blob/428d94dd66c7cd72be53e3a9d4f9753cc612d878/ygnmi/gnmi.go#L273). This means the `receiveStream` goroutine will never return, and will be leaked.

In our application we're stress testing a lot of reconnections where we call `WatchAll` multiple times, so we were seeing 100s of goroutines leak this way. This change just makes the `errCh` buffered such that the write to it tolerates the receiver having gone away. Given that it's only used for errors in the data being received and the `w.errCh` is buffered that it writes into in streamed cases, this seemed a NOOP for functionality.
