### PR TITLE
Fix Batch Generation to only generate on root

### DIFF
--- a/pathgen/gnmigen.go
+++ b/pathgen/gnmigen.go
@@ -146,7 +146,7 @@ func defaultTmplStruct(pathStructName string, node *NodeData) gnmiStruct {
 
 // generateOneOff generates one-off free-form generated code.
 func generateOneOff(b *strings.Builder, node *NodeData, tmplStruct gnmiStruct, compressPaths bool) error {
-	if node.SubsumingGoStructName == fakeRootName {
+	if strings.TrimLeft(node.LocalGoTypeName, "*") == fakeRootName {
 		tmplStruct.MethodName = "Query"
 		if compressPaths {
 			tmplStruct.MethodName = "State"

--- a/pathgen/gnmigen_test.go
+++ b/pathgen/gnmigen_test.go
@@ -134,6 +134,99 @@ func (n *Container_LeafAny) State() ygnmi.WildcardQuery[int32] {
 }
 `,
 	}, {
+		desc:           "scalar leaf without config directly below root",
+		dir:            dirs["/root"],
+		pathStructName: "Leaf",
+		node: &NodeData{
+			GoTypeName:            "int32",
+			LocalGoTypeName:       "int32",
+			GoFieldName:           "Leaf",
+			YANGFieldName:         "leaf",
+			SubsumingGoStructName: "Root",
+			IsLeaf:                true,
+			IsScalarField:         true,
+			HasDefault:            true,
+			YANGPath:              "/leaf",
+		},
+		want: `
+// State returns a Query that can be used in gNMI operations.
+// 	Defining module:      "root-module"
+// 	Instantiating module: "root-module"
+// 	Path from parent:     "leaf"
+// 	Path from root:       "/leaf"
+func (n *Leaf) State() ygnmi.SingletonQuery[int32] {
+	return ygnmi.NewSingletonQuery[int32](
+		"Root",
+		true,
+		true,
+		true,
+		true,
+		false,
+		ygnmi.NewNodePath(
+			[]string{"leaf"},
+			nil,
+			n.parent,
+		),
+		func(gs ygot.ValidatedGoStruct) (int32, bool) { 
+			ret := gs.(*oc.Root).Leaf
+			if ret == nil {
+				var zero int32
+				return zero, false
+			}
+			return *ret, true
+		},
+		func() ygot.ValidatedGoStruct { return new(oc.Root) },
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+		nil,
+		nil,
+	)
+}
+
+// State returns a Query that can be used in gNMI operations.
+// 	Defining module:      "root-module"
+// 	Instantiating module: "root-module"
+// 	Path from parent:     "leaf"
+// 	Path from root:       "/leaf"
+func (n *LeafAny) State() ygnmi.WildcardQuery[int32] {
+	return ygnmi.NewWildcardQuery[int32](
+		"Root",
+		true,
+		true,
+		true,
+		true,
+		false,
+		ygnmi.NewNodePath(
+			[]string{"leaf"},
+			nil,
+			n.parent,
+		),
+		func(gs ygot.ValidatedGoStruct) (int32, bool) { 
+			ret := gs.(*oc.Root).Leaf
+			if ret == nil {
+				var zero int32
+				return zero, false
+			}
+			return *ret, true
+		},
+		func() ygot.ValidatedGoStruct { return new(oc.Root) },
+		func() *ytypes.Schema {
+			return &ytypes.Schema{
+				Root:       &oc.Root{},
+				SchemaTree: oc.SchemaTree,
+				Unmarshal:  oc.Unmarshal,
+			}
+		},
+		nil,
+	)
+}
+`,
+	}, {
 		desc:           "scalar leaf with config",
 		dir:            dirs["/root-module/container-with-config"],
 		pathStructName: "Container_LeafList",
@@ -389,7 +482,7 @@ func (n *Container_LeafAny) State() ygnmi.WildcardQuery[E_Child_Three] {
 		pathStructName: "Root",
 		node: &NodeData{
 			GoTypeName:            "*oc.Root",
-			LocalGoTypeName:       "Root",
+			LocalGoTypeName:       "*Root",
 			GoFieldName:           "",
 			YANGFieldName:         "",
 			SubsumingGoStructName: "Root",


### PR DESCRIPTION
Currently it's also generating for each non-GoStruct below root (e.g. list), which errors out if there are multiple of them in the under the same module/package.