### PR TITLE
Use new UntypedQuery for Batch.AddPaths

### DIFF
--- a/ygnmi/ygnmi_test.go
+++ b/ygnmi/ygnmi_test.go
@@ -4221,7 +4221,7 @@ func TestCustomRootBatch(t *testing.T) {
 	tests := []struct {
 		desc                 string
 		stub                 func(s *testutil.Stubber)
-		paths                []ygnmi.PathStruct
+		paths                []ygnmi.UntypedQuery
 		wantSubscriptionPath []*gpb.Path
 		wantVal              *ygnmi.Value[*exampleoc.Parent]
 		wantAddErr           string
@@ -4229,8 +4229,8 @@ func TestCustomRootBatch(t *testing.T) {
 	}{{
 		desc: "not prefix",
 		stub: func(s *testutil.Stubber) {},
-		paths: []ygnmi.PathStruct{
-			exampleocpath.Root().Model(),
+		paths: []ygnmi.UntypedQuery{
+			exampleocpath.Root().Model().Config(),
 		},
 		wantAddErr: "is not a prefix",
 	}, {
@@ -4244,8 +4244,8 @@ func TestCustomRootBatch(t *testing.T) {
 				}},
 			}).Sync()
 		},
-		paths: []ygnmi.PathStruct{
-			exampleocpath.Root().Parent().Child().Two(),
+		paths: []ygnmi.UntypedQuery{
+			exampleocpath.Root().Parent().Child().Two().State(),
 		},
 		wantSubscriptionPath: []*gpb.Path{
 			twoPath,
@@ -4333,8 +4333,8 @@ func TestCustomRootBatch(t *testing.T) {
 		modelPath := exampleocpath.Root().Model()
 		b := ygnmi.NewBatch(modelPath.SingleKeyMap().State())
 		if err := b.AddPaths(
-			modelPath.SingleKeyAny().Key().State().PathStruct(),
-			modelPath.SingleKeyAny().Value().State().PathStruct(),
+			modelPath.SingleKeyAny().Key().State(),
+			modelPath.SingleKeyAny().Value().State(),
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -4384,7 +4384,7 @@ func TestCustomRootWildcardBatch(t *testing.T) {
 	tests := []struct {
 		desc                 string
 		stub                 func(s *testutil.Stubber)
-		paths                []ygnmi.PathStruct
+		paths                []ygnmi.UntypedQuery
 		wantSubscriptionPath []*gpb.Path
 		wantVal              []*ygnmi.Value[*exampleoc.Model_SingleKey]
 		wantAddErr           string
@@ -4392,8 +4392,8 @@ func TestCustomRootWildcardBatch(t *testing.T) {
 	}{{
 		desc: "not prefix",
 		stub: func(s *testutil.Stubber) {},
-		paths: []ygnmi.PathStruct{
-			exampleocpath.Root().Model(),
+		paths: []ygnmi.UntypedQuery{
+			exampleocpath.Root().Model().Config(),
 		},
 		wantAddErr: "is not a prefix",
 	}, {
@@ -4410,9 +4410,9 @@ func TestCustomRootWildcardBatch(t *testing.T) {
 				}},
 			}).Sync()
 		},
-		paths: []ygnmi.PathStruct{
-			exampleocpath.Root().Model().SingleKeyAny().Value().State().PathStruct(),
-			exampleocpath.Root().Model().SingleKeyAny().Key().State().PathStruct(),
+		paths: []ygnmi.UntypedQuery{
+			exampleocpath.Root().Model().SingleKeyAny().Value().State(),
+			exampleocpath.Root().Model().SingleKeyAny().Key().State(),
 		},
 		wantSubscriptionPath: []*gpb.Path{
 			keyPathWild,

--- a/ygnmi/ygnmi_uncompressed_test.go
+++ b/ygnmi/ygnmi_uncompressed_test.go
@@ -459,7 +459,7 @@ func TestUncompressedCustomRootBatch(t *testing.T) {
 	tests := []struct {
 		desc                 string
 		stub                 func(s *testutil.Stubber)
-		paths                []ygnmi.PathStruct
+		paths                []ygnmi.UntypedQuery
 		wantSubscriptionPath []*gpb.Path
 		wantVal              *ygnmi.Value[*uexampleoc.OpenconfigSimple_Parent]
 		wantAddErr           string
@@ -467,7 +467,7 @@ func TestUncompressedCustomRootBatch(t *testing.T) {
 	}{{
 		desc: "not prefix",
 		stub: func(s *testutil.Stubber) {},
-		paths: []ygnmi.PathStruct{
+		paths: []ygnmi.UntypedQuery{
 			uexampleocpath.Root().Model(),
 		},
 		wantAddErr: "is not a prefix",
@@ -482,7 +482,7 @@ func TestUncompressedCustomRootBatch(t *testing.T) {
 				}},
 			}).Sync()
 		},
-		paths: []ygnmi.PathStruct{
+		paths: []ygnmi.UntypedQuery{
 			uexampleocpath.Root().Parent().Child().State().Two(),
 		},
 		wantSubscriptionPath: []*gpb.Path{


### PR DESCRIPTION
There is still the root-level batch in the generated code. I'm not removing it for now since it does offer the ability to do Config() and State() queries. That being said for API consistency we might want to remove it anyways in a follow-up PR.