### PR TITLE
Improve style of context.go

### DIFF
--- a/ygnmi/context.go
+++ b/ygnmi/context.go
@@ -20,12 +20,12 @@ import (
 
 // RequestValues contains request-scoped values for ygnmi queries.
 type RequestValues struct {
-	// CompressedConfigQuery is a key type that means that the query is
-	// uninterested in /state paths.
-	CompressedConfigQuery bool
-	// CompressedStateQuery is a key type that means that the query is
-	// uninterested in /config paths.
-	CompressedStateQuery bool
+	// StateFiltered is a key type that means that the query is
+	// uninterested in /state paths and will filter them out.
+	StateFiltered bool
+	// ConfigFiltered is a key type that means that the query is
+	// uninterested in /config paths and will filter them out.
+	ConfigFiltered bool
 }
 
 // FromContext extracts certain ygnmi request-scoped values, if present.
@@ -37,8 +37,8 @@ func FromContext(ctx context.Context) *RequestValues {
 // NewContext returns a new Context carrying ygnmi request-scoped values.
 func NewContext(ctx context.Context, q UntypedQuery) context.Context {
 	return context.WithValue(ctx, requestValuesKey{}, &RequestValues{
-		CompressedConfigQuery: q.isCompressedSchema() && !q.IsState(),
-		CompressedStateQuery:  q.isCompressedSchema() && q.IsState(),
+		StateFiltered:  q.isCompressedSchema() && !q.IsState(),
+		ConfigFiltered: q.isCompressedSchema() && q.IsState(),
 	})
 }
 

--- a/ygnmi/context_test.go
+++ b/ygnmi/context_test.go
@@ -33,50 +33,50 @@ func TestFromContext(t *testing.T) {
 		desc:      "compress-config",
 		inContext: ygnmi.NewContext(context.Background(), exampleocpath.Root().Parent().Config()),
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: true,
-			CompressedStateQuery:  false,
+			StateFiltered:  true,
+			ConfigFiltered: false,
 		},
 	}, {
 		desc:      "compress-config-leaf",
 		inContext: ygnmi.NewContext(context.Background(), exampleocpath.Root().Parent().Child().Five().Config()),
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: true,
-			CompressedStateQuery:  false,
+			StateFiltered:  true,
+			ConfigFiltered: false,
 		},
 	}, {
 		desc:      "compress-state",
 		inContext: ygnmi.NewContext(context.Background(), exampleocpath.Root().Parent().State()),
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  true,
+			StateFiltered:  false,
+			ConfigFiltered: true,
 		},
 	}, {
 		desc:      "compress-state-leaf",
 		inContext: ygnmi.NewContext(context.Background(), exampleocpath.Root().Parent().Child().Five().State()),
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  true,
+			StateFiltered:  false,
+			ConfigFiltered: true,
 		},
 	}, {
 		desc:      "uncompressed-container",
 		inContext: ygnmi.NewContext(context.Background(), uexampleocpath.Root().Parent()),
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  false,
+			StateFiltered:  false,
+			ConfigFiltered: false,
 		},
 	}, {
 		desc:      "uncompressed-config-container",
 		inContext: ygnmi.NewContext(context.Background(), uexampleocpath.Root().Parent().Child().Config()),
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  false,
+			StateFiltered:  false,
+			ConfigFiltered: false,
 		},
 	}, {
 		desc:      "uncompressed-leaf",
 		inContext: ygnmi.NewContext(context.Background(), uexampleocpath.Root().Parent().Child().Config().Five()),
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  false,
+			StateFiltered:  false,
+			ConfigFiltered: false,
 		},
 	}}
 

--- a/ygnmi/ygnmi_preferconfig_test.go
+++ b/ygnmi/ygnmi_preferconfig_test.go
@@ -134,8 +134,8 @@ func TestPreferConfigLookup(t *testing.T) {
 			}).Sync()
 		},
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  true,
+			StateFiltered:  false,
+			ConfigFiltered: true,
 		},
 		wantSubscriptionPath: leafPath,
 		wantVal: (&ygnmi.Value[string]{
@@ -329,8 +329,8 @@ func TestPreferConfigLookup(t *testing.T) {
 		},
 		inQuery: configQuery,
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: true,
-			CompressedStateQuery:  false,
+			StateFiltered:  true,
+			ConfigFiltered: false,
 		},
 		wantSubscriptionPath: rootPath,
 		wantVal: (&ygnmi.Value[*exampleocconfig.Parent_Child]{
@@ -352,8 +352,8 @@ func TestPreferConfigLookup(t *testing.T) {
 		},
 		inQuery: stateQuery,
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  true,
+			StateFiltered:  false,
+			ConfigFiltered: true,
 		},
 		wantSubscriptionPath: rootPath,
 		wantVal: (&ygnmi.Value[*exampleocconfig.Parent_Child]{
@@ -376,8 +376,8 @@ func TestPreferConfigLookup(t *testing.T) {
 		},
 		inQuery: stateQuery,
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  true,
+			StateFiltered:  false,
+			ConfigFiltered: true,
 		},
 		wantSubscriptionPath: rootPath,
 		wantVal: (&ygnmi.Value[*exampleocconfig.Parent_Child]{
@@ -399,8 +399,8 @@ func TestPreferConfigLookup(t *testing.T) {
 		},
 		inQuery: configQuery,
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: true,
-			CompressedStateQuery:  false,
+			StateFiltered:  true,
+			ConfigFiltered: false,
 		},
 		wantSubscriptionPath: rootPath,
 		wantVal: (&ygnmi.Value[*exampleocconfig.Parent_Child]{
@@ -480,8 +480,8 @@ func TestPreferConfigLookup(t *testing.T) {
 		},
 		inQuery: stateQuery,
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  true,
+			StateFiltered:  false,
+			ConfigFiltered: true,
 		},
 		wantSubscriptionPath: rootPath,
 		wantVal: (&ygnmi.Value[*exampleocconfig.Parent_Child]{
@@ -692,8 +692,8 @@ func TestPreferConfigLookupWithGet(t *testing.T) {
 				exampleocconfigpath.Root().RemoteContainer().ALeaf().State(),
 				"",
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				tt.wantRequest,
 				tt.wantVal,
@@ -773,8 +773,8 @@ func TestPreferConfigLookupWithGet(t *testing.T) {
 				ygnmi.SingletonQuery[*exampleocconfig.Parent_Child](path),
 				"",
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: true,
-					CompressedStateQuery:  false,
+					StateFiltered:  true,
+					ConfigFiltered: false,
 				},
 				&gpb.GetRequest{
 					Encoding: gpb.Encoding_JSON_IETF,
@@ -950,8 +950,8 @@ func TestPreferConfigGet(t *testing.T) {
 			getCheckFn(
 				t, fakeGNMI, c, lq, tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				tt.wantSubscriptionPath, tt.wantVal)
 		})
@@ -1224,8 +1224,8 @@ func TestPreferConfigWatch(t *testing.T) {
 				func(val string) bool { return val == "foo" },
 				tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				[]*gpb.Path{tt.wantSubscriptionPath},
 				[]gpb.SubscriptionMode{tt.wantMode},
@@ -1460,8 +1460,8 @@ func TestPreferConfigWatch(t *testing.T) {
 				},
 				tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				[]*gpb.Path{tt.wantSubscriptionPath},
 				[]gpb.SubscriptionMode{gpb.SubscriptionMode_TARGET_DEFINED},
@@ -1912,8 +1912,8 @@ func TestPreferConfigCollect(t *testing.T) {
 			collectCheckFn(
 				t, fakeGNMI, client, lq, tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				tt.wantSubscriptionPath, tt.wantVals,
 			)
@@ -1995,8 +1995,8 @@ func TestPreferConfigCollect(t *testing.T) {
 			collectCheckFn(
 				t, fakeGNMI, client, nonLeafQuery, tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				tt.wantSubscriptionPath, tt.wantVals)
 		})
@@ -2157,8 +2157,8 @@ func TestPreferConfigLookupAll(t *testing.T) {
 			tt.stub(fakeGNMI.Stub())
 			lookupAllCheckFn(t, fakeGNMI, c, lq, tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				tt.wantSubscriptionPath, tt.wantVals, false,
 			)
@@ -2277,8 +2277,8 @@ func TestPreferConfigLookupAll(t *testing.T) {
 			lookupAllCheckFn(
 				t, fakeGNMI, c, nonLeafQ, tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				tt.wantSubscriptionPath, tt.wantVals, true,
 			)

--- a/ygnmi/ygnmi_test.go
+++ b/ygnmi/ygnmi_test.go
@@ -132,8 +132,8 @@ func TestLookup(t *testing.T) {
 			}).Sync()
 		},
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  true,
+			StateFiltered:  false,
+			ConfigFiltered: true,
 		},
 		wantSubscriptionPath: leafPath,
 		wantVal: (&ygnmi.Value[string]{
@@ -327,8 +327,8 @@ func TestLookup(t *testing.T) {
 		},
 		inQuery: configQuery,
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: true,
-			CompressedStateQuery:  false,
+			StateFiltered:  true,
+			ConfigFiltered: false,
 		},
 		wantSubscriptionPath: rootPath,
 		wantVal: (&ygnmi.Value[*exampleoc.Parent_Child]{
@@ -350,8 +350,8 @@ func TestLookup(t *testing.T) {
 		},
 		inQuery: stateQuery,
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  true,
+			StateFiltered:  false,
+			ConfigFiltered: true,
 		},
 		wantSubscriptionPath: rootPath,
 		wantVal: (&ygnmi.Value[*exampleoc.Parent_Child]{
@@ -374,8 +374,8 @@ func TestLookup(t *testing.T) {
 		},
 		inQuery: stateQuery,
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  true,
+			StateFiltered:  false,
+			ConfigFiltered: true,
 		},
 		wantSubscriptionPath: rootPath,
 		wantVal: (&ygnmi.Value[*exampleoc.Parent_Child]{
@@ -397,8 +397,8 @@ func TestLookup(t *testing.T) {
 		},
 		inQuery: configQuery,
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: true,
-			CompressedStateQuery:  false,
+			StateFiltered:  true,
+			ConfigFiltered: false,
 		},
 		wantSubscriptionPath: rootPath,
 		wantVal: (&ygnmi.Value[*exampleoc.Parent_Child]{
@@ -478,8 +478,8 @@ func TestLookup(t *testing.T) {
 		},
 		inQuery: stateQuery,
 		wantRequestValues: &ygnmi.RequestValues{
-			CompressedConfigQuery: false,
-			CompressedStateQuery:  true,
+			StateFiltered:  false,
+			ConfigFiltered: true,
 		},
 		wantSubscriptionPath: rootPath,
 		wantVal: (&ygnmi.Value[*exampleoc.Parent_Child]{
@@ -690,8 +690,8 @@ func TestLookupWithGet(t *testing.T) {
 				exampleocpath.Root().RemoteContainer().ALeaf().State(),
 				"",
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				tt.wantRequest,
 				tt.wantVal,
@@ -771,8 +771,8 @@ func TestLookupWithGet(t *testing.T) {
 				ygnmi.SingletonQuery[*exampleoc.Parent_Child](path),
 				"",
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: true,
-					CompressedStateQuery:  false,
+					StateFiltered:  true,
+					ConfigFiltered: false,
 				},
 				&gpb.GetRequest{
 					Encoding: gpb.Encoding_JSON_IETF,
@@ -948,8 +948,8 @@ func TestGet(t *testing.T) {
 			getCheckFn(
 				t, fakeGNMI, c, lq, tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				tt.wantSubscriptionPath, tt.wantVal)
 		})
@@ -1222,8 +1222,8 @@ func TestWatch(t *testing.T) {
 				func(val string) bool { return val == "foo" },
 				tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				[]*gpb.Path{tt.wantSubscriptionPath},
 				[]gpb.SubscriptionMode{tt.wantMode},
@@ -1458,8 +1458,8 @@ func TestWatch(t *testing.T) {
 				},
 				tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				[]*gpb.Path{tt.wantSubscriptionPath},
 				[]gpb.SubscriptionMode{gpb.SubscriptionMode_TARGET_DEFINED},
@@ -1910,8 +1910,8 @@ func TestCollect(t *testing.T) {
 			collectCheckFn(
 				t, fakeGNMI, client, lq, tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				tt.wantSubscriptionPath, tt.wantVals,
 			)
@@ -1993,8 +1993,8 @@ func TestCollect(t *testing.T) {
 			collectCheckFn(
 				t, fakeGNMI, client, nonLeafQuery, tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				tt.wantSubscriptionPath, tt.wantVals)
 		})
@@ -2155,8 +2155,8 @@ func TestLookupAll(t *testing.T) {
 			tt.stub(fakeGNMI.Stub())
 			lookupAllCheckFn(t, fakeGNMI, c, lq, tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				tt.wantSubscriptionPath, tt.wantVals, false,
 			)
@@ -2275,8 +2275,8 @@ func TestLookupAll(t *testing.T) {
 			lookupAllCheckFn(
 				t, fakeGNMI, c, nonLeafQ, tt.wantErr,
 				&ygnmi.RequestValues{
-					CompressedConfigQuery: false,
-					CompressedStateQuery:  true,
+					StateFiltered:  false,
+					ConfigFiltered: true,
 				},
 				tt.wantSubscriptionPath, tt.wantVals, true,
 			)


### PR DESCRIPTION
Addressed comments from https://github.com/openconfig/ygnmi/pull/139

**Backwards-incompatible** due to name change.

It's better to make the breaking change earlier rather than later.