### PR TITLE
Add generator command option to set the path origin from the YANG module name or an specified name

### DIFF
--- a/app/ygnmi/cmd/generator/generator.go
+++ b/app/ygnmi/cmd/generator/generator.go
@@ -66,6 +66,8 @@ func New() *cobra.Command {
 	generator.Flags().Bool("shorten_enum_leaf_names", true, "If also set to true when compress_paths=true, all leaves of type enumeration will by default not be prefixed with the name of its residing module.")
 	generator.Flags().Bool("annotations", false, "If set to true, metadata annotations are added within the ygot-generated structs.")
 	generator.Flags().Bool("prefer_operational_state", true, "If set to true, state (config false) fields in the YANG schema are preferred over intended config leaves in the generated Go code with compressed schema paths. This flag is only valid for compress_paths=true.")
+	generator.Flags().Bool("use_module_name_as_path_origin", false, "If set to true, the YANG module name will be used as the origin in the generated gNMI paths.")
+	generator.Flags().String("set_path_origin", "", "Change the name of the origin in the generated gNMI paths.")	
 
 	// TODO(wenovus): Delete these hidden flags before or on v1 release.
 	generator.Flags().Bool("typedef_enum_with_defmod", true, "If set to true, all typedefs of type enumeration or identity will be prefixed with the name of its module of definition instead of its residing module.")
@@ -180,6 +182,8 @@ func generate(cmd *cobra.Command, args []string) error {
 		IgnoreAtomic:            !viper.GetBool("generate_atomic"),
 		IgnoreAtomicLists:       !viper.GetBool("generate_atomic_lists"),
 		SplitPackagePaths:       splitPackagePaths,
+		UseModuleNameAsPathOrigin:  viper.GetBool("use_module_name_as_path_origin"),
+		PathOriginName:		 viper.GetString("set_path_origin"),		
 	}
 
 	pathCode, _, errs := pcg.GeneratePathCode(args, viper.GetStringSlice("paths"))
@@ -239,6 +243,8 @@ func generateStructs(modules []string, schemaPath, version, fakeRootName string,
 				UseDefiningModuleForTypedefEnumNames: viper.GetBool("typedef_enum_with_defmod"),
 				EnumerationsUseUnderscores:           true,
 			},
+			UseModuleNameAsPathOrigin: viper.GetBool("use_module_name_as_path_origin"),
+			PathOriginName: viper.GetString("set_path_origin"),			
 		},
 		gogen.GoOpts{
 			PackageName:                         path.Base(schemaPath),

--- a/ygnmi/gnmi.go
+++ b/ygnmi/gnmi.go
@@ -557,6 +557,11 @@ func resolvePath(q PathStruct) (*gpb.Path, error) {
 	if err != nil {
 		return nil, err
 	}
+	if originSetter, ok := q.(interface{ PathOriginName() string }); ok {
+	   	// When the path struct has the method PathOriginName(),
+		// then the output of the method is set to the path.Origin
+		path.Origin = originSetter.PathOriginName()
+	}	
 	if origin, ok := opts[OriginOverride]; ok {
 		path.Origin = origin.(string)
 	}


### PR DESCRIPTION
ygnmi/ygot generated gNMI messages are sent with the YANG module name or an arbitrarily name as the path.origin specified by generator command option.
e.g.
```
go run github.com/openconfig/ygnmi/app/ygnmi generator \
  --compress_paths=false \
  --base_package_path=github.com/openconfig/ondatra/gnmi/xr792 \
  --output_dir=gnmi/xr792 \
  --paths=/opt/NativeYangModel/vendor/cisco/xr/792/... \
  --ignore_deviate_notsupported \
  --set_path_origin=Cisco-IOS-XR-ifmgr-cfg or --use_module_name_as_path_origin \ 
  "${XR792_YANG_FILES[@]}"
```

-Reason for changes
Cisco IOS-XR returns an error when a ygnmi/ygot generated gNMI message from the vendor native yang module, e.g. Cisco-IOS-XR-ifmgr-cfg.yang, because of the unexpected path.origin and desires the yang module name there. However, the current ygnmi implementation, i.e. ygnmi/gnmi.go, hardcodes "openconfig" to all the path.origin.
["PathStruct should contain origin information #615"](https://github.com/openconfig/ygot/issues/615) opened at Jan. 2022 is a related issue.


-Summary of changes
1. ygnmi/app/ygnmi/cmd/generator/generator.go
Add --use_module_name_as_path_origin option to the generator command and set the UseModuleNameAsPathOrigin field of the pathgen.GenConfig struct(i), pcg, to pass it to the GeneratePathCode() function called from the generate() function.
And, set the UseModuleNameAsPathOrigin field of the ygen.IROptions struct to pass it to the gogen.New() function in the generateStructs() function also called from the generate() function.

Similarly, add --set_path_origin option and set the path origin name specified by the option to the PathOriginName field of the pathgen.GenConfig struct(ii) and the PathOriginName field of the ygen.IROptions struct(ii).


2. ygnmi/pathgen/pathgen.go
Add UseModuleNameAsPathOrigin and PathOriginName fields to the GenConfig struct used by the above (i) and (ii).

In the GeneratePathCode() function, copy the values of the UseModuleNameAsPathOrigin and PathOriginName fields of the parent GenConfig struct to the respective fields of ygen.IROptions struct.

Add the PathOriginName field to the NodeData struct used by (iii) below.

Add the PathOriginName() function to the goPathStructTemplate template used by the PathStruct generated from the YANG model at (v) below.

In the getNodeDataMap() function:
If the PathOriginName filed of the IR struct, ir, has a value, copy it to the PathOriginName field of the NodeData struct, nodeData(iii).
Else if the value of UseModuleNameAsPathOrigin field of the IR struct, ir, is True, copy the value of field.YANGDetails.RootElementModule, i.e. YANG module name, to the PathOriginName field.

Add the PathOriginName field to the goPathStructData struct used by (iv) below.

In the generateDirectorySnippet() function, copy the PathOriginName field of the NodeData struct, nodeData, to the PathOriginName field in the goPathStruct struct, structData(iv), to pass it to the PathStruct generated from the YANG model by using the goPathStructTemplate template.


3. ygot/ygen/genir.go (applied to ygot pkg)
Add UseModuleNameAsPathOrigin and PathOriginName fields to the IROptions struct used by the above (ii).


4. ygot/ygen/ir.go (applied to ygot pkg)
Add UseModuleNameAsPathOrigin and PathOriginName fields to the IR struct used by the above (iii).


5. ygnmi/ygnmi/gnmi.go
Set the value of the PathOriginName to the path.Origin by using the PathOriginName() function(v).