### PR TITLE
Allow more control over gnmi set request marshalling

### DIFF
--- a/ygnmi/gnmi.go
+++ b/ygnmi/gnmi.go
@@ -554,7 +554,7 @@ func populateSetRequest(req *gpb.SetRequest, path *gpb.Path, val interface{}, op
 		}
 
 		var modifyTypedValueFn func(*gpb.TypedValue) error
-		if !isLeaf && compressInfo != nil && len(compressInfo.PostRelPath) > 0 {
+		if !isLeaf && compressInfo != nil && len(compressInfo.PostRelPath) > 0 && len(typedVal.GetJsonIetfVal()) > 0 {
 			// When the path struct points to a node that's compressed out,
 			// then we know that the type is a node lower than it should be
 			// as far as the JSON is concerned.

--- a/ygnmi/gnmi.go
+++ b/ygnmi/gnmi.go
@@ -517,12 +517,22 @@ func populateSetRequest(req *gpb.SetRequest, path *gpb.Path, val interface{}, op
 		} else if s, ok := val.(string); ok && strings.HasSuffix(path.Origin, "_cli") {
 			typedVal = &gpb.TypedValue{Value: &gpb.TypedValue_AsciiVal{AsciiVal: s}}
 		} else if opt.preferProto {
-			typedVal, err = ygot.EncodeTypedValue(val, gpb.Encoding_JSON_IETF, &ygot.RFC7951JSONConfig{AppendModuleName: true, PreferShadowPath: preferShadowPath})
+			typedVal, err = ygot.EncodeTypedValue(val, gpb.Encoding_JSON_IETF, &ygot.RFC7951JSONConfig{AppendModuleName: opt.appendModuleName, PreferShadowPath: preferShadowPath})
 		} else {
-			typedVal = &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{}}
 			// Since the GoStructs are generated using preferOperationalState, we
 			// need to turn on preferShadowPath to prefer marshalling config paths.
-			typedVal.Value.(*gpb.TypedValue_JsonIetfVal).JsonIetfVal, err = ygot.Marshal7951(val, ygot.JSONIndent("  "), &ygot.RFC7951JSONConfig{AppendModuleName: true, PreferShadowPath: preferShadowPath})
+			var b []byte
+			b, err = ygot.Marshal7951(val, ygot.JSONIndent("  "), &ygot.RFC7951JSONConfig{AppendModuleName: opt.appendModuleName, PreferShadowPath: preferShadowPath})
+
+			// Respect the encoding option.
+			switch opt.encoding {
+			case gpb.Encoding_JSON:
+				typedVal = &gpb.TypedValue{Value: &gpb.TypedValue_JsonVal{JsonVal: b}}
+			case gpb.Encoding_JSON_IETF:
+				fallthrough
+			default:
+				typedVal = &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{JsonIetfVal: b}}
+			}
 		}
 
 		if err != nil && opt.setFallback && path.Origin != "openconfig" {

--- a/ygnmi/ygnmi.go
+++ b/ygnmi/ygnmi.go
@@ -335,14 +335,14 @@ func WithDatapointValidator(fn ValidateFn) Option {
 	}
 }
 
-// WithAppendModuleName creates an option that determines whether the module name is prepended to
+// WithSkipModuleNames creates an option that avoids prepending the module name to
 // elements that are defined within a different YANG module than their parent.
 //
 // By default, the module name is prepended to the element name, e.g. "openconfig-interfaces:interface".
 // Use this option to disable this behavior.
-func WithAppendModuleName(append bool) Option {
+func WithSkipModuleNames() Option {
 	return func(o *opt) {
-		o.appendModuleName = append
+		o.appendModuleName = false
 	}
 }
 

--- a/ygnmi/ygnmi.go
+++ b/ygnmi/ygnmi.go
@@ -258,13 +258,15 @@ type opt struct {
 	setFallback        bool
 	sampleInterval     uint64
 	datapointValidator ValidateFn
+	appendModuleName   bool
 	ft                 FunctionalTranslator
 }
 
 // resolveOpts applies all the options and returns a struct containing the result.
 func resolveOpts(opts []Option) *opt {
 	o := &opt{
-		encoding: gpb.Encoding_PROTO,
+		encoding:         gpb.Encoding_PROTO,
+		appendModuleName: true,
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -330,6 +332,12 @@ func WithSetFallbackEncoding() Option {
 func WithDatapointValidator(fn ValidateFn) Option {
 	return func(o *opt) {
 		o.datapointValidator = fn
+	}
+}
+
+func WithAppendModuleName(append bool) Option {
+	return func(o *opt) {
+		o.appendModuleName = append
 	}
 }
 

--- a/ygnmi/ygnmi.go
+++ b/ygnmi/ygnmi.go
@@ -335,6 +335,11 @@ func WithDatapointValidator(fn ValidateFn) Option {
 	}
 }
 
+// WithAppendModuleName creates an option that determines whether the module name is prepended to
+// elements that are defined within a different YANG module than their parent.
+//
+// By default, the module name is prepended to the element name, e.g. "openconfig-interfaces:interface".
+// Use this option to disable this behavior.
 func WithAppendModuleName(append bool) Option {
 	return func(o *opt) {
 		o.appendModuleName = append


### PR DESCRIPTION
This patch extends the current behavior to populate the gnmi set request in order to allow more control over the request payload.

1. A new `WithAppendModuleName` option is added that allows to toggle the procedure of adding the YANG module name to the respective fields, which is redundant for systems that will automatically infer the module name via other means.
2. The `WithEncoding` option is respected when set to json encoding. Previously the typed value was marshalled by default as json_ietf, while certain platform such as Cisco NX-OS only support json enconding and therefore expect all request to be encoded as such. With this option, it's now possible to encode request to json if desired.

All changes mentioned above do not alter the current behavior. They simply allow for more flexibility when used explicitly by providing the respective options.