### PR TITLE
Make AppendModuleName an option of the batch Set request

### DIFF
--- a/ygnmi/gnmi.go
+++ b/ygnmi/gnmi.go
@@ -516,12 +516,12 @@ func populateSetRequest(req *gpb.SetRequest, path *gpb.Path, val interface{}, op
 		} else if s, ok := val.(string); ok && strings.HasSuffix(path.Origin, "_cli") {
 			typedVal = &gpb.TypedValue{Value: &gpb.TypedValue_AsciiVal{AsciiVal: s}}
 		} else if opt.preferProto {
-			typedVal, err = ygot.EncodeTypedValue(val, gpb.Encoding_JSON_IETF, &ygot.RFC7951JSONConfig{AppendModuleName: true, PreferShadowPath: preferShadowPath})
+			typedVal, err = ygot.EncodeTypedValue(val, gpb.Encoding_JSON_IETF, &ygot.RFC7951JSONConfig{AppendModuleName: opt.appendModuleName, PreferShadowPath: preferShadowPath})
 		} else {
 			typedVal = &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{}}
 			// Since the GoStructs are generated using preferOperationalState, we
 			// need to turn on preferShadowPath to prefer marshalling config paths.
-			typedVal.Value.(*gpb.TypedValue_JsonIetfVal).JsonIetfVal, err = ygot.Marshal7951(val, ygot.JSONIndent("  "), &ygot.RFC7951JSONConfig{AppendModuleName: true, PreferShadowPath: preferShadowPath})
+			typedVal.Value.(*gpb.TypedValue_JsonIetfVal).JsonIetfVal, err = ygot.Marshal7951(val, ygot.JSONIndent("  "), &ygot.RFC7951JSONConfig{AppendModuleName: opt.appendModuleName, PreferShadowPath: preferShadowPath})
 		}
 
 		if err != nil && opt.setFallback && path.Origin != "openconfig" {

--- a/ygnmi/ygnmi.go
+++ b/ygnmi/ygnmi.go
@@ -259,12 +259,14 @@ type opt struct {
 	sampleInterval     uint64
 	datapointValidator ValidateFn
 	ft                 FunctionalTranslator
+	appendModuleName   bool
 }
 
 // resolveOpts applies all the options and returns a struct containing the result.
 func resolveOpts(opts []Option) *opt {
 	o := &opt{
-		encoding: gpb.Encoding_PROTO,
+		encoding:         gpb.Encoding_PROTO,
+		appendModuleName: true,
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -372,6 +374,14 @@ func WithDatapointValidator(fn ValidateFn) Option {
 func WithFT(ft FunctionalTranslator) Option {
 	return func(o *opt) {
 		o.ft = ft
+	}
+}
+
+// WithoutAppendModuleName creates an option to set AppendModuleName to false when marshalling the RFC 7951 config.
+// This can only be used on Set.
+func WithoutAppendModuleName() Option {
+	return func(o *opt) {
+		o.appendModuleName = false
 	}
 }
 


### PR DESCRIPTION
Certain vendor's reject Set requests with the module name prepended to enum types. This should be configurable just like it is when using the ygot API directly.

Still working with my employer's legal team so I can sign the Google CLA. Should have that done within a couple weeks.