### PR TITLE
union-replace-remove-eos-append-origin

### DIFF
--- a/ygnmi/gnmi.go
+++ b/ygnmi/gnmi.go
@@ -513,7 +513,7 @@ func populateSetRequest(req *gpb.SetRequest, path *gpb.Path, val interface{}, op
 		var err error
 		if s, ok := val.(*string); ok && path.Origin == "cli" {
 			typedVal = &gpb.TypedValue{Value: &gpb.TypedValue_AsciiVal{AsciiVal: *s}}
-		} else if s, ok := val.(string); ok && strings.HasSuffix(path.Origin, "_cli") {
+		} else if s, ok := val.(string); ok && (strings.HasSuffix(path.Origin, "_cli") || path.Origin == "cli") {
 			typedVal = &gpb.TypedValue{Value: &gpb.TypedValue_AsciiVal{AsciiVal: s}}
 		} else if opt.preferProto {
 			typedVal, err = ygot.EncodeTypedValue(val, gpb.Encoding_JSON_IETF, &ygot.RFC7951JSONConfig{AppendModuleName: opt.appendModuleName, PreferShadowPath: preferShadowPath})

--- a/ygnmi/path_types.go
+++ b/ygnmi/path_types.go
@@ -92,6 +92,9 @@ func (d *DeviceRootBase) CustomData() map[string]interface{} {
 
 // PutCustomData modifies an entry in the customData field of the DeviceRootBase struct.
 func (d *DeviceRootBase) PutCustomData(key string, val interface{}) {
+	if val == "eos_cli" {
+		val = "cli"
+	}
 	d.customData[key] = val
 }
 


### PR DESCRIPTION
Removed Arista EOS from being appended when doing union-replace with CLI
[For issue - 173](https://github.com/openconfig/ygnmi/issues/173)